### PR TITLE
fix: add tests to tsconfig for development

### DIFF
--- a/packages/brightness/package.json
+++ b/packages/brightness/package.json
@@ -28,7 +28,7 @@
 	"scripts": {
 		"lint": "tsc --noEmit && eslint ./src --ext ts",
 		"test": "jest",
-		"build": "tsc"
+		"build": "tsc --build tsconfig.build.json"
 	},
 	"devDependencies": {
 		"@types/jest": "^24.0.13",

--- a/packages/brightness/tsconfig.build.json
+++ b/packages/brightness/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"./src"
+	]
+}

--- a/packages/brightness/tsconfig.json
+++ b/packages/brightness/tsconfig.json
@@ -4,6 +4,7 @@
 		"outDir": "./build"
 	},
 	"include": [
-		"./src"
+		"./src",
+		"./tests"
 	]
 }

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -28,7 +28,7 @@
 	"scripts": {
 		"lint": "tsc --noEmit && eslint ./src --ext ts",
 		"test": "jest",
-		"build": "tsc"
+		"build": "tsc --build tsconfig.build.json"
 	},
 	"devDependencies": {
 		"@types/jest": "^24.0.13",

--- a/packages/permissions/tsconfig.build.json
+++ b/packages/permissions/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"./src"
+	]
+}

--- a/packages/permissions/tsconfig.json
+++ b/packages/permissions/tsconfig.json
@@ -4,6 +4,7 @@
 		"outDir": "./build"
 	},
 	"include": [
-		"./src"
+		"./src",
+		"./tests"
 	]
 }

--- a/packages/sensors/package.json
+++ b/packages/sensors/package.json
@@ -28,7 +28,7 @@
 	"scripts": {
 		"lint": "tsc --noEmit && eslint ./src --ext ts",
 		"test": "jest",
-		"build": "tsc"
+		"build": "tsc --build tsconfig.build.json"
 	},
 	"devDependencies": {
 		"@types/jest": "^24.0.13",

--- a/packages/sensors/tsconfig.build.json
+++ b/packages/sensors/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"./src"
+	]
+}

--- a/packages/sensors/tsconfig.json
+++ b/packages/sensors/tsconfig.json
@@ -4,6 +4,7 @@
 		"outDir": "./build"
 	},
 	"include": [
-		"./src"
+		"./src",
+		"./tests"
 	]
 }


### PR DESCRIPTION
### Linked issue
When building, it's being excluded to only build the source files. It's a dirty fix, but one that works.
