### PR TITLE
Add first draft of screen orientation lock hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 - [**Screen Orientation**](./packages/screen-orientation)
     - [`useScreenOrientation`](./packages/screen-orientation/docs/use-screen-orientation.md) &mdash; tracks changes in screen orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
+    - [`useScreenOrientationLock`](./packages/screen-orientation/docs/use-screen-orientation-lock.md) &mdash; locks the screen to an orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
 
 - [**Sensors**](./packages/sensors)
     - [`useAccelerometer`](./packages/sensors/docs/use-accelerometer.md) &mdash; tracks changes in acceleration with [`Accelerometer`](https://docs.expo.io/versions/latest/sdk/accelerometer/)

--- a/packages/brightness/package-lock.json
+++ b/packages/brightness/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@use-expo/brightness",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/permissions/package-lock.json
+++ b/packages/permissions/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@use-expo/permissions",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/screen-orientation/README.md
+++ b/packages/screen-orientation/README.md
@@ -22,6 +22,7 @@
 </div>
 
 - [`useScreenOrientation`](./docs/use-screen-orientation.md) &mdash; tracks changes in screen orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
+- [`useScreenOrientationLock`](./docs/use-screen-orientation-lock.md) &mdash; locks the screen to an orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
 
 <div align="center">
     <br />

--- a/packages/screen-orientation/docs/use-screen-orientation-lock.md
+++ b/packages/screen-orientation/docs/use-screen-orientation-lock.md
@@ -1,0 +1,45 @@
+<div align="center">
+    <h1>
+        <br />
+        <code>useScreenOrientationLock</code>
+        <br />
+        <br />
+    </h1>
+    locks the screen to an orientation with <a href="https://docs.expo.io/versions/latest/sdk/screen-orientation/"><code>ScreenOrientation</code></a>
+    <br />
+</div>
+
+## Examples
+
+```jsx
+// full hook
+useScreenOrientationLock(OrientationLock.LANDSCAPE_LEFT);
+```
+
+With the `useScreenOrientationLock` hook we can create a simple example.
+
+```jsx
+function ScreenOrientationLockExample() {
+    useScreenOrientationLock(OrientationLock.PORTRAIT_UP);
+
+    return (
+        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+            <Text>This screen is now locked to portrait mode</Text>
+        </View>
+    );
+}
+```
+
+## API
+
+```ts
+function useScreenOrientationLock(orientation: ScreenOrientation.OrientationLock): void;
+```
+
+<div align="center">
+    <br />
+    <br />
+    with :heart: <strong>byCedric</strong>
+    <br />
+    <br />
+</div>

--- a/packages/screen-orientation/package-lock.json
+++ b/packages/screen-orientation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@use-expo/screen-orientation",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/screen-orientation/src/index.ts
+++ b/packages/screen-orientation/src/index.ts
@@ -1,1 +1,2 @@
 export * from './use-screen-orientation';
+export * from './use-screen-orientation-lock';

--- a/packages/screen-orientation/src/use-screen-orientation-lock.ts
+++ b/packages/screen-orientation/src/use-screen-orientation-lock.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+import { ScreenOrientation } from 'expo';
+
+export function useScreenOrientationLock(orientation: ScreenOrientation.OrientationLock): void {
+	useEffect(() => {
+		ScreenOrientation.lockAsync(orientation);
+		return () => ScreenOrientation.unlockAsync();
+	}, [orientation]);
+}

--- a/packages/screen-orientation/tests/use-screen-orientation-lock.test.ts
+++ b/packages/screen-orientation/tests/use-screen-orientation-lock.test.ts
@@ -1,0 +1,30 @@
+const { ScreenOrientation } = jest.genMockFromModule('expo');
+
+jest.mock('expo', () => ({ ScreenOrientation }));
+
+import { renderHook } from 'react-hooks-testing-library';
+import { useScreenOrientationLock } from '../src/use-screen-orientation-lock';
+
+const { OrientationLock } = ScreenOrientation;
+
+test('locks the screen to orientation when mounted', () => {
+	renderHook(() => useScreenOrientationLock(OrientationLock.PORTRAIT_UP));
+	expect(ScreenOrientation.lockAsync).toBeCalledWith(OrientationLock.PORTRAIT_UP);
+});
+
+test('unlocks the screen to orientation when unmounted', () => {
+	const hook = renderHook(() => useScreenOrientationLock(OrientationLock.PORTRAIT_UP));
+	hook.unmount();
+	expect(ScreenOrientation.unlockAsync).toBeCalled();
+});
+
+test('refreshes the lock when orientation is changed', () => {
+	let orientation = OrientationLock.PORTRAIT_UP;
+	const hook = renderHook(() => useScreenOrientationLock(orientation));
+
+	orientation = OrientationLock.LANDSCAPE_RIGHT;
+	hook.rerender();
+
+	expect(ScreenOrientation.unlockAsync).toBeCalled();
+	expect(ScreenOrientation.lockAsync).toBeCalledWith(OrientationLock.LANDSCAPE_RIGHT)
+});

--- a/packages/sensors/package-lock.json
+++ b/packages/sensors/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@use-expo/sensors",
-	"version": "0.5.0",
+	"version": "0.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
### Linked issue
This adds a basic screen orientation lock hook, based on the [`useKeepAwake` hook from Expo](https://github.com/expo/expo/blob/master/packages/expo-keep-awake/src/index.ts#L40-L45).