### PR TITLE
chore(example): add react hooks eslint rules

### DIFF
--- a/example/.eslintrc.json
+++ b/example/.eslintrc.json
@@ -1,7 +1,8 @@
 {
 	"parser": "@typescript-eslint/parser",
 	"plugins": [
-		"@typescript-eslint"
+		"@typescript-eslint",
+		"react-hooks"
 	],
 	"env": {
 		"node": true
@@ -22,7 +23,9 @@
 		"@typescript-eslint/no-non-null-assertion": "off",
 		"@typescript-eslint/no-use-before-define": "off",
 		"react/no-unescaped-entities": "off",
-		"react/prop-types": "off"
+		"react/prop-types": "off",
+		"react-hooks/rules-of-hooks": "error",
+		"react-hooks/exhaustive-deps": "warn"
 	},
 	"settings": {
 		"react": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -2972,6 +2972,12 @@
 				}
 			}
 		},
+		"eslint-plugin-react-hooks": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
+			"integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==",
+			"dev": true
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/example/package.json
+++ b/example/package.json
@@ -35,6 +35,7 @@
 		"babel-preset-expo": "^5.1.1",
 		"eslint": "^5.16.0",
 		"eslint-plugin-react": "^7.14.2",
+		"eslint-plugin-react-hooks": "^1.6.1",
 		"typescript": "^3.4.5"
 	}
 }


### PR DESCRIPTION
# Additional details
This adds the two ESLint hooks rules to the example project. It's a basic security to double check if all hooks are implemented properly.