### PR TITLE
fix: allow latest expo modules as peer dependencies

### DIFF
--- a/packages/brightness/package.json
+++ b/packages/brightness/package.json
@@ -50,6 +50,6 @@
 		"typescript": "^3.5.3"
 	},
 	"peerDependencies": {
-		"expo-brightness": "^5.0.1"
+		"expo-brightness": ">=5.0.1"
 	}
 }

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -51,7 +51,7 @@
 		"typescript": "^3.5.1"
 	},
 	"peerDependencies": {
-		"expo-asset": "^5.0.1",
-		"expo-font": "^5.0.1"
+		"expo-asset": ">=5.0.1",
+		"expo-font": ">=5.0.1"
 	}
 }

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -50,6 +50,6 @@
 		"typescript": "^3.5.3"
 	},
 	"peerDependencies": {
-		"expo-permissions": "^5.0.1"
+		"expo-permissions": ">=5.0.1"
 	}
 }

--- a/packages/sensors/package.json
+++ b/packages/sensors/package.json
@@ -50,6 +50,6 @@
 		"typescript": "^3.5.3"
 	},
 	"peerDependencies": {
-		"expo-sensors": "^5.0.1"
+		"expo-sensors": ">=5.0.1"
 	}
 }


### PR DESCRIPTION
### Linked issue
This fixes the warning about peer dependencies not installed for newer expo `6.x.x` modules.
