### PR TITLE
fix: add missing commitlint to github workflow

### DIFF
--- a/.github/workflows/example-ci.yml
+++ b/.github/workflows/example-ci.yml
@@ -24,3 +24,4 @@ jobs:
         working-directory: example
       - run: npm run test
         working-directory: example
+      - uses: bycedric/commitlint-action@master

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '!example/**'
+      - '**'
 jobs:
   ci:
     name: Install, test and lint

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -1,10 +1,6 @@
 ---
 name: Packages CI
-on:
-  pull_request:
-    paths:
-      - '!example/**'
-      - '**'
+on: [push]
 jobs:
   ci:
     name: Install, test and lint

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -19,3 +19,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test
+      - uses: bycedric/commitlint-action@master


### PR DESCRIPTION
### Linked issue
Commitlint was missing from the new github workflows.