### PR TITLE
refactor(example): update expo action version to v4

### DIFF
--- a/.github/workflows/example-publish.yml
+++ b/.github/workflows/example-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - uses: expo/expo-github-action@refactor/update-action
+      - uses: expo/expo-github-action@v4
         with:
           expo-version: 3.x
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}


### PR DESCRIPTION
### Linked issue
New Expo GitHub Action v4 is out, let's use that one.
