### PR TITLE
refactor: use latest expo github action with cache

### DIFF
--- a/.github/workflows/example-publish.yml
+++ b/.github/workflows/example-publish.yml
@@ -15,8 +15,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - uses: expo/expo-github-action@v4
+      - uses: expo/expo-github-action@v5
         with:
+          expo-cache: true
           expo-version: 3.x
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}


### PR DESCRIPTION
### Linked issue
This adds some caching to the Expo CLI, and should speed up our builds.
