### PR TITLE
fix(brightness): fetch brighness mode after new props

### DIFF
--- a/NEW_PEDOMETER_HISTORY.ats
+++ b/NEW_PEDOMETER_HISTORY.ats
@@ -1,0 +1,44 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Pedometer } from 'expo-sensors';
+import { PedometerMeasurement, PedometerOptions } from './use-pedometer';
+
+export function usePedometerHistory(
+	start: Date,
+	end: Date,
+	options: PedometerHistoryOptions = {},
+): UsePedometerHistorySignature {
+	const [data, setData] = useState(options.initial);
+	const [available, setAvailable] = useState<boolean>();
+	const {
+		get = true,
+		availability = true,
+	} = options;
+
+	const getHistory = useCallback(
+		() => Pedometer.getStepCountAsync(start, end).then(setData),
+		[start, end]
+	);
+
+	useEffect(() => {
+		if (availability) {
+			Pedometer.isAvailableAsync().then(setAvailable);
+		}
+
+		if (get) {
+			getHistory();
+		}
+	}, [availability, get, getHistory]);
+
+	return [data, available, getHistory];
+}
+
+type UsePedometerHistorySignature = [
+	PedometerMeasurement | undefined,
+	boolean | undefined,
+	() => Promise<void>,
+];
+
+export interface PedometerHistoryOptions extends PedometerOptions {
+	/** If it should fetch the pedometer step count when mounted, defaults to `true`. */
+	get?: boolean;
+}

--- a/packages/brightness/src/use-system-brightness-mode.ts
+++ b/packages/brightness/src/use-system-brightness-mode.ts
@@ -20,8 +20,10 @@ export function useSystemBrightnessMode(
 	}
 
 	useEffect(() => {
-		if (get) getSystemBrightnessMode();
-	}, []);
+		if (get) {
+			getSystemBrightnessMode();
+		}
+	}, [get]);
 
 	return [data, setSystemBrightnessMode, getSystemBrightnessMode];
 }

--- a/packages/brightness/tests/use-system-brightness-mode.test.ts
+++ b/packages/brightness/tests/use-system-brightness-mode.test.ts
@@ -29,7 +29,7 @@ it('updates data with get callback', async () => {
 		.mockResolvedValueOnce(Brightness.BrightnessMode.AUTOMATIC)
 		.mockResolvedValueOnce(Brightness.BrightnessMode.MANUAL);
 
-	const hook = renderHook(useSystemBrightnessMode);
+	const hook = renderHook(() => useSystemBrightnessMode());
 	await hook.waitForNextUpdate();
 
 	expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.AUTOMATIC);
@@ -38,4 +38,22 @@ it('updates data with get callback', async () => {
 
 	expect(getter).toBeCalledTimes(2);
 	expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.MANUAL);
+});
+
+describe('options', () => {
+	it('updates data with get callback, after initial render', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessModeAsync').mockResolvedValue(Brightness.BrightnessMode.MANUAL);
+
+		const hook = renderHook(
+			props => useSystemBrightnessMode(props),
+			{ initialProps: { get: false } },
+		);
+
+		expect(hook.result.current[DATA]).toBeUndefined();
+
+		hook.rerender({ get: true });
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.MANUAL);
+	});
 });


### PR DESCRIPTION
### Linked issue
This fixes the hook dependency warning for the brightness hooks.
