### PR TITLE
feat(screen-orientation): add manual get callback and listen option

### DIFF
--- a/packages/screen-orientation/tests/use-screen-orientation-lock.test.ts
+++ b/packages/screen-orientation/tests/use-screen-orientation-lock.test.ts
@@ -3,14 +3,14 @@ import * as Expo from 'expo';
 import { useScreenOrientationLock } from '../src/use-screen-orientation-lock';
 import { OrientationLock } from './types';
 
-it('locks the screen to orientation when mounted', () => {
+it('locks the orientation when mounted', () => {
 	const locker = jest.spyOn(Expo.ScreenOrientation, 'lockAsync').mockResolvedValue();
 
 	renderHook(() => useScreenOrientationLock(OrientationLock.PORTRAIT_UP));
 	expect(locker).toBeCalledWith(OrientationLock.PORTRAIT_UP);
 });
 
-it('unlocks the screen to orientation when unmounted', () => {
+it('unlocks the orientation when unmounted', () => {
 	jest.spyOn(Expo.ScreenOrientation, 'lockAsync').mockResolvedValue();
 	const unlocker = jest.spyOn(Expo.ScreenOrientation, 'unlockAsync').mockResolvedValue();
 
@@ -30,6 +30,7 @@ it('updates the lock when orientation is changed', () => {
 	);
 	hook.rerender(OrientationLock.LANDSCAPE_RIGHT);
 
+	expect(locker).toBeCalledWith(OrientationLock.PORTRAIT_UP);
 	expect(unlocker).toBeCalled();
 	expect(locker).toBeCalledWith(OrientationLock.LANDSCAPE_RIGHT);
 });


### PR DESCRIPTION
### Linked issue
This improves the screen orientation hook by adding:
  - `getScreenOrientation` callback, to manually update the orientation
  - `listen` option, to disable orientation changes

It also restructures the screen orientation hook's tests, for more readability.