### PR TITLE
refactor(sensors): rework tests and properly use dependencies

### DIFF
--- a/example/src/molecules/sensors/use-pedometer.tsx
+++ b/example/src/molecules/sensors/use-pedometer.tsx
@@ -7,10 +7,10 @@ import { docs } from '../../providers/urls';
 
 export const UsePedometer: React.SFC<MoleculeProps> = (props) => {
 	const [live, liveAvailable] = usePedometer();
-	const [history, historyAvailable] = usePedometerHistory(
-		new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
-		new Date(),
-	);
+	const [history, historyAvailable] = usePedometerHistory({
+		start: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
+		end: new Date(),
+	});
 
 	return (
 		<Page

--- a/packages/sensors/src/use-accelerometer.ts
+++ b/packages/sensors/src/use-accelerometer.ts
@@ -4,19 +4,22 @@ import { Accelerometer, ThreeAxisMeasurement } from 'expo-sensors';
 export function useAccelerometer(options: AccelerometerOptions = {}): UseAccelerometerSignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		interval,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
 			Accelerometer.isAvailableAsync().then(setAvailable);
 		}
 
-		if (options.interval !== undefined) {
-			Accelerometer.setUpdateInterval(options.interval);
+		if (interval !== undefined) {
+			Accelerometer.setUpdateInterval(interval);
 		}
 
 		return Accelerometer.addListener(setData).remove;
-	}, []);
+	}, [availability, interval]);
 
 	return [data, available];
 }

--- a/packages/sensors/src/use-barometer.ts
+++ b/packages/sensors/src/use-barometer.ts
@@ -4,19 +4,22 @@ import { Barometer, BarometerMeasurement } from 'expo-sensors';
 export function useBarometer(options: BarometerOptions = {}): UseBarometerSignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		interval,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
 			Barometer.isAvailableAsync().then(setAvailable);
 		}
 
-		if (options.interval !== undefined) {
-			Barometer.setUpdateInterval(options.interval);
+		if (interval !== undefined) {
+			Barometer.setUpdateInterval(interval);
 		}
 
 		return Barometer.addListener(setData).remove;
-	}, []);
+	}, [availability, interval]);
 
 	return [data, available];
 }

--- a/packages/sensors/src/use-device-motion.ts
+++ b/packages/sensors/src/use-device-motion.ts
@@ -4,19 +4,22 @@ import { DeviceMotion, DeviceMotionMeasurement } from 'expo-sensors';
 export function useDeviceMotion(options: DeviceMotionOptions = {}): UseDeviceMotionSignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		interval,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
 			DeviceMotion.isAvailableAsync().then(setAvailable);
 		}
 
-		if (options.interval !== undefined) {
-			DeviceMotion.setUpdateInterval(options.interval);
+		if (interval !== undefined) {
+			DeviceMotion.setUpdateInterval(interval);
 		}
 
 		return DeviceMotion.addListener(setData).remove;
-	}, []);
+	}, [availability, interval]);
 
 	return [data, available];
 }

--- a/packages/sensors/src/use-gyroscope.ts
+++ b/packages/sensors/src/use-gyroscope.ts
@@ -4,19 +4,22 @@ import { Gyroscope, ThreeAxisMeasurement } from 'expo-sensors';
 export function useGyroscope(options: GyroscopeOptions = {}): UseGyroscopeSignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		interval,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
 			Gyroscope.isAvailableAsync().then(setAvailable);
 		}
 
-		if (options.interval !== undefined) {
-			Gyroscope.setUpdateInterval(options.interval);
+		if (interval !== undefined) {
+			Gyroscope.setUpdateInterval(interval);
 		}
 
 		return Gyroscope.addListener(setData).remove;
-	}, []);
+	}, [availability, interval]);
 
 	return [data, available];
 }

--- a/packages/sensors/src/use-magnetometer-uncalibrated.ts
+++ b/packages/sensors/src/use-magnetometer-uncalibrated.ts
@@ -6,19 +6,22 @@ export function useMagnetometerUncalibrated(
 ): UseMagnetometerUncalibratedSignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		interval,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
 			MagnetometerUncalibrated.isAvailableAsync().then(setAvailable);
 		}
 
-		if (options.interval !== undefined) {
-			MagnetometerUncalibrated.setUpdateInterval(options.interval);
+		if (interval !== undefined) {
+			MagnetometerUncalibrated.setUpdateInterval(interval);
 		}
 
 		return MagnetometerUncalibrated.addListener(setData).remove;
-	}, []);
+	}, [availability, interval]);
 
 	return [data, available];
 }

--- a/packages/sensors/src/use-magnetometer.ts
+++ b/packages/sensors/src/use-magnetometer.ts
@@ -4,19 +4,22 @@ import { Magnetometer, ThreeAxisMeasurement } from 'expo-sensors';
 export function useMagnetometer(options: MagnetometerOptions = {}): UseMagnetometerSignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		interval,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
 			Magnetometer.isAvailableAsync().then(setAvailable);
 		}
 
-		if (options.interval !== undefined) {
-			Magnetometer.setUpdateInterval(options.interval);
+		if (interval !== undefined) {
+			Magnetometer.setUpdateInterval(interval);
 		}
 
 		return Magnetometer.addListener(setData).remove;
-	}, []);
+	}, [availability, interval]);
 
 	return [data, available];
 }

--- a/packages/sensors/src/use-pedometer-history.ts
+++ b/packages/sensors/src/use-pedometer-history.ts
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 import { Pedometer } from 'expo-sensors';
-import { PedometerMeasurement, PedometerOptions } from './use-pedometer';
+import { PedometerResult, PedometerOptions } from './use-pedometer';
 
-export function usePedometerHistory(
-	start: Date,
-	end: Date,
-	options: PedometerOptions = {},
-): UsePedometerHistorySignature {
+export function usePedometerHistory(options: PedometerHistpryOptions): UsePedometerHistorySignature {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
-	const { availability = true } = options;
+	const {
+		availability = true,
+		start,
+		end,
+	} = options;
 
 	useEffect(() => {
 		if (availability) {
@@ -17,12 +17,28 @@ export function usePedometerHistory(
 		}
 
 		Pedometer.getStepCountAsync(start, end).then(setData);
-	}, []);
+	}, [availability, start, end]);
 
 	return [data, available];
 }
 
 type UsePedometerHistorySignature = [
-	PedometerMeasurement | undefined,
+	PedometerResult | undefined,
 	boolean | undefined,
 ];
+
+export interface PedometerHistpryOptions extends PedometerOptions {
+	/**
+	 * The start of the range to fetch the step count.
+	 *
+	 * @see https://docs.expo.io/versions/latest/sdk/pedometer/#pedometergetstepcountasyncstart-end
+	 */
+	start: Date;
+
+	/**
+	 * The end of the range to fetch the step count.
+	 *
+	 * @see https://docs.expo.io/versions/latest/sdk/pedometer/#pedometergetstepcountasyncstart-end
+	 */
+	end: Date;
+}

--- a/packages/sensors/src/use-pedometer.ts
+++ b/packages/sensors/src/use-pedometer.ts
@@ -12,24 +12,25 @@ export function usePedometer(options: PedometerOptions = {}): UsePedometerSignat
 		}
 
 		return Pedometer.watchStepCount(setData).remove;
-	}, []);
+	}, [availability]);
 
 	return [data, available];
 }
 
 type UsePedometerSignature = [
-	PedometerMeasurement | undefined,
+	PedometerResult | undefined,
 	boolean | undefined,
 ];
 
-export interface PedometerMeasurement {
+// note: this isn't exported from expo, so we need to duplicate it
+export interface PedometerResult {
 	/** The amount of steps made */
 	steps: number;
 }
 
 export interface PedometerOptions {
 	/** The initial data to use before the first update. */
-	initial?: PedometerMeasurement;
+	initial?: PedometerResult;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
 }

--- a/packages/sensors/tests/use-accelerometer.test.ts
+++ b/packages/sensors/tests/use-accelerometer.test.ts
@@ -5,35 +5,21 @@ import { useAccelerometer } from '../src/use-accelerometer';
 const DATA = 0;
 const AVAILABLE = 1;
 
-it('returns data and availability when mounted', async () => {
+const fakeData = (): Sensors.ThreeAxisMeasurement => ({
+	x: Math.random(),
+	y: Math.random(),
+	z: Math.random(),
+});
+
+it('returns default values when mounted', async () => {
 	const hook = renderHook(() => useAccelerometer({ availability: false }));
 
 	expect(hook.result.current[DATA]).toBeUndefined();
 	expect(hook.result.current[AVAILABLE]).toBeUndefined();
 });
 
-it('updates accelerometer availability', async () => {
-	jest.spyOn(Sensors.Accelerometer, 'isAvailableAsync').mockResolvedValue(true);
-
-	const hook = renderHook(() => useAccelerometer());
-	await hook.waitForNextUpdate();
-
-	expect(hook.result.current[AVAILABLE]).toBe(true);
-});
-
-it('updates accelerometer data', async () => {
-	const listener = jest.spyOn(Sensors.Accelerometer, 'addListener');
-	const data = { x: 0, y: 1, z: 0.5 };
-
-	const hook = renderHook(() => useAccelerometer({ availability: false }));
-	const handler = listener.mock.calls[0][0];
-	act(() => handler(data));
-
-	expect(hook.result.current[DATA]).toMatchObject(data);
-});
-
-describe('event listener', () => {
-	it('subscribes when mounted', () => {
+describe('listener', () => {
+	it('subscribes when mounted', async () => {
 		const listener = jest.spyOn(Sensors.Accelerometer, 'addListener');
 
 		renderHook(() => useAccelerometer({ availability: false }));
@@ -41,7 +27,7 @@ describe('event listener', () => {
 		expect(listener).toBeCalled();
 	});
 
-	it('unsubscribes when unmounted', () => {
+	it('unsubscribes when unmounted', async () => {
 		const subscription = { remove: jest.fn() };
 		jest.spyOn(Sensors.Accelerometer, 'addListener').mockReturnValue(subscription);
 
@@ -50,29 +36,75 @@ describe('event listener', () => {
 
 		expect(subscription.remove).toBeCalled();
 	});
+
+	it('updates data from subscription', async () => {
+		const data = fakeData();
+		const listener = jest.spyOn(Sensors.Accelerometer, 'addListener');
+
+		const hook = renderHook(() => useAccelerometer({ availability: false }));
+		const handler = listener.mock.calls[0][0];
+		await act(() => {
+			handler(data);
+			return hook.waitForNextUpdate();
+		});
+
+		expect(hook.result.current[DATA]).toBe(data);
+	});
 });
 
-describe('options', () => {
-	it('uses initial data', () => {
-		const initial = { x: 0.5, y: 0.2, z: 0.3 };
-		const hook = renderHook(() => useAccelerometer({ initial, availability: false }));
+describe('availability option', () => {
+	it('gets availability info when mounted', async () => {
+		jest.spyOn(Sensors.Accelerometer, 'isAvailableAsync').mockResolvedValue(true);
 
-		expect(hook.result.current[DATA]).toMatchObject(initial);
+		const hook = renderHook(() => useAccelerometer({ availability: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
 	});
 
-	it('uses interval duration', () => {
+	it('gets availability when rerendered', async () => {
+		jest.spyOn(Sensors.Accelerometer, 'isAvailableAsync').mockResolvedValue(true);
+
+		const hook = renderHook(useAccelerometer, { initialProps: { availability: false } });
+		hook.rerender({ availability: true })
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
+	});
+});
+
+describe('initial option', () => {
+	it('uses initial data when mounted', async () => {
+		const data = fakeData();
+		const hook = renderHook(() => useAccelerometer({ availability: false, initial: data }));
+
+		expect(hook.result.current[DATA]).toMatchObject(data);
+	});
+
+	it('does not change initial data when rerendered', async () => {
+		const data = { old: fakeData(), new: fakeData() };
+		const hook = renderHook(() => useAccelerometer({ availability: false, initial: data.old }));
+		hook.rerender({ availability: false, initial: data.new })
+
+		expect(hook.result.current[DATA]).toMatchObject(data.old);
+	});
+});
+
+describe('interval option', () => {
+	it('sets interval duration when mounted', async () => {
 		const setter = jest.spyOn(Sensors.Accelerometer, 'setUpdateInterval');
 
-		renderHook(() => useAccelerometer({ interval: 1500, availability: false }));
+		renderHook(() => useAccelerometer({ availability: false, interval: 1500 }));
 
 		expect(setter).toBeCalledWith(1500);
 	});
 
-	it('skips availability check', () => {
-		const checker = jest.spyOn(Sensors.Accelerometer, 'isAvailableAsync');
+	it('changes interval duration when rerendered', async () => {
+		const setter = jest.spyOn(Sensors.Accelerometer, 'setUpdateInterval');
 
-		renderHook(() => useAccelerometer({ availability: false }));
+		const hook = renderHook(useAccelerometer, { initialProps: { availability: false } });
+		hook.rerender({ availability: false, interval: 750 });
 
-		expect(checker).not.toBeCalled();
+		expect(setter).toBeCalledWith(750);
 	});
 });

--- a/packages/sensors/tests/use-gyroscope.test.ts
+++ b/packages/sensors/tests/use-gyroscope.test.ts
@@ -5,35 +5,21 @@ import { useGyroscope } from '../src/use-gyroscope';
 const DATA = 0;
 const AVAILABLE = 1;
 
-it('returns data and availability when mounted', () => {
+const fakeData = (): Sensors.ThreeAxisMeasurement => ({
+	x: Math.random(),
+	y: Math.random(),
+	z: Math.random(),
+});
+
+it('returns default values when mounted', async () => {
 	const hook = renderHook(() => useGyroscope({ availability: false }));
 
 	expect(hook.result.current[DATA]).toBeUndefined();
 	expect(hook.result.current[AVAILABLE]).toBeUndefined();
 });
 
-it('handles gyroscope availability', async () => {
-	jest.spyOn(Sensors.Gyroscope, 'isAvailableAsync').mockResolvedValue(true);
-
-	const hook = renderHook(useGyroscope);
-	await hook.waitForNextUpdate();
-
-	expect(hook.result.current[AVAILABLE]).toBe(true);
-});
-
-it('updates gyroscope data', async () => {
-	const listener = jest.spyOn(Sensors.Gyroscope, 'addListener');
-	const data = { x: 0, y: 1, z: 0.5 };
-
-	const hook = renderHook(() => useGyroscope({ availability: false }));
-	const handler = listener.mock.calls[0][0];
-	act(() => handler(data));
-
-	expect(hook.result.current[DATA]).toMatchObject(data);
-});
-
-describe('event listener', () => {
-	it('subscribes when mounted', () => {
+describe('listener', () => {
+	it('subscribes when mounted', async () => {
 		const listener = jest.spyOn(Sensors.Gyroscope, 'addListener');
 
 		renderHook(() => useGyroscope({ availability: false }));
@@ -41,7 +27,7 @@ describe('event listener', () => {
 		expect(listener).toBeCalled();
 	});
 
-	it('unsubscribes when unmounted', () => {
+	it('unsubscribes when unmounted', async () => {
 		const subscription = { remove: jest.fn() };
 		jest.spyOn(Sensors.Gyroscope, 'addListener').mockReturnValue(subscription);
 
@@ -50,29 +36,75 @@ describe('event listener', () => {
 
 		expect(subscription.remove).toBeCalled();
 	});
+
+	it('updates data from subscription', async () => {
+		const data = fakeData();
+		const listener = jest.spyOn(Sensors.Gyroscope, 'addListener');
+
+		const hook = renderHook(() => useGyroscope({ availability: false }));
+		const handler = listener.mock.calls[0][0];
+		await act(() => {
+			handler(data);
+			return hook.waitForNextUpdate();
+		});
+
+		expect(hook.result.current[DATA]).toBe(data);
+	});
 });
 
-describe('options', () => {
-	it('uses initial data', () => {
-		const initial = { x: 1, y: 1, z: 1 };
-		const hook = renderHook(() => useGyroscope({ initial, availability: false }));
+describe('availability option', () => {
+	it('gets availability info when mounted', async () => {
+		jest.spyOn(Sensors.Gyroscope, 'isAvailableAsync').mockResolvedValue(true);
 
-		expect(hook.result.current[DATA]).toMatchObject(initial);
+		const hook = renderHook(() => useGyroscope({ availability: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
 	});
 
-	it('uses interval duration', () => {
+	it('gets availability when rerendered', async () => {
+		jest.spyOn(Sensors.Gyroscope, 'isAvailableAsync').mockResolvedValue(true);
+
+		const hook = renderHook(useGyroscope, { initialProps: { availability: false } });
+		hook.rerender({ availability: true })
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
+	});
+});
+
+describe('initial option', () => {
+	it('uses initial data when mounted', async () => {
+		const data = fakeData();
+		const hook = renderHook(() => useGyroscope({ availability: false, initial: data }));
+
+		expect(hook.result.current[DATA]).toMatchObject(data);
+	});
+
+	it('does not change initial data when rerendered', async () => {
+		const data = { old: fakeData(), new: fakeData() };
+		const hook = renderHook(() => useGyroscope({ availability: false, initial: data.old }));
+		hook.rerender({ availability: false, initial: data.new })
+
+		expect(hook.result.current[DATA]).toMatchObject(data.old);
+	});
+});
+
+describe('interval option', () => {
+	it('sets interval duration when mounted', async () => {
 		const setter = jest.spyOn(Sensors.Gyroscope, 'setUpdateInterval');
 
-		renderHook(() => useGyroscope({ interval: 1500, availability: false }));
+		renderHook(() => useGyroscope({ availability: false, interval: 1500 }));
 
 		expect(setter).toBeCalledWith(1500);
 	});
 
-	it('skips availability check', () => {
-		const checker = jest.spyOn(Sensors.Gyroscope, 'isAvailableAsync');
+	it('changes interval duration when rerendered', async () => {
+		const setter = jest.spyOn(Sensors.Gyroscope, 'setUpdateInterval');
 
-		renderHook(() => useGyroscope({ availability: false }));
+		const hook = renderHook(useGyroscope, { initialProps: { availability: false } });
+		hook.rerender({ availability: false, interval: 750 });
 
-		expect(checker).not.toBeCalled();
+		expect(setter).toBeCalledWith(750);
 	});
 });

--- a/packages/sensors/tests/use-magnetometer.test.ts
+++ b/packages/sensors/tests/use-magnetometer.test.ts
@@ -5,35 +5,21 @@ import { useMagnetometer } from '../src/use-magnetometer';
 const DATA = 0;
 const AVAILABLE = 1;
 
-it('returns data and availability when mounted', async () => {
+const fakeData = (): Sensors.ThreeAxisMeasurement => ({
+	x: Math.random(),
+	y: Math.random(),
+	z: Math.random(),
+});
+
+it('returns default values when mounted', async () => {
 	const hook = renderHook(() => useMagnetometer({ availability: false }));
 
 	expect(hook.result.current[DATA]).toBeUndefined();
 	expect(hook.result.current[AVAILABLE]).toBeUndefined();
 });
 
-it('updates magnetometer availability', async () => {
-	jest.spyOn(Sensors.Magnetometer, 'isAvailableAsync').mockResolvedValue(true);
-
-	const hook = renderHook(() => useMagnetometer());
-	await hook.waitForNextUpdate();
-
-	expect(hook.result.current[AVAILABLE]).toBe(true);
-});
-
-it('updates magnetometer data', async () => {
-	const listener = jest.spyOn(Sensors.Magnetometer, 'addListener');
-	const data = { x: 0, y: 1, z: 0.5 };
-
-	const hook = renderHook(() => useMagnetometer({ availability: false }));
-	const handler = listener.mock.calls[0][0];
-	act(() => handler(data));
-
-	expect(hook.result.current[DATA]).toMatchObject(data);
-});
-
-describe('event listener', () => {
-	it('subscribes when mounted', () => {
+describe('listener', () => {
+	it('subscribes when mounted', async () => {
 		const listener = jest.spyOn(Sensors.Magnetometer, 'addListener');
 
 		renderHook(() => useMagnetometer({ availability: false }));
@@ -41,7 +27,7 @@ describe('event listener', () => {
 		expect(listener).toBeCalled();
 	});
 
-	it('unsubscribes when unmounted', () => {
+	it('unsubscribes when unmounted', async () => {
 		const subscription = { remove: jest.fn() };
 		jest.spyOn(Sensors.Magnetometer, 'addListener').mockReturnValue(subscription);
 
@@ -50,29 +36,75 @@ describe('event listener', () => {
 
 		expect(subscription.remove).toBeCalled();
 	});
+
+	it('updates data from subscription', async () => {
+		const data = fakeData();
+		const listener = jest.spyOn(Sensors.Magnetometer, 'addListener');
+
+		const hook = renderHook(() => useMagnetometer({ availability: false }));
+		const handler = listener.mock.calls[0][0];
+		await act(() => {
+			handler(data);
+			return hook.waitForNextUpdate();
+		});
+
+		expect(hook.result.current[DATA]).toBe(data);
+	});
 });
 
-describe('options', () => {
-	it('uses initial data', () => {
-		const initial = { x: 0.5, y: 0.2, z: 0.3 };
-		const hook = renderHook(() => useMagnetometer({ initial, availability: false }));
+describe('availability option', () => {
+	it('gets availability info when mounted', async () => {
+		jest.spyOn(Sensors.Magnetometer, 'isAvailableAsync').mockResolvedValue(true);
 
-		expect(hook.result.current[DATA]).toMatchObject(initial);
+		const hook = renderHook(() => useMagnetometer({ availability: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
 	});
 
-	it('uses interval duration', () => {
+	it('gets availability when rerendered', async () => {
+		jest.spyOn(Sensors.Magnetometer, 'isAvailableAsync').mockResolvedValue(true);
+
+		const hook = renderHook(useMagnetometer, { initialProps: { availability: false } });
+		hook.rerender({ availability: true })
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
+	});
+});
+
+describe('initial option', () => {
+	it('uses initial data when mounted', async () => {
+		const data = fakeData();
+		const hook = renderHook(() => useMagnetometer({ availability: false, initial: data }));
+
+		expect(hook.result.current[DATA]).toMatchObject(data);
+	});
+
+	it('does not change initial data when rerendered', async () => {
+		const data = { old: fakeData(), new: fakeData() };
+		const hook = renderHook(() => useMagnetometer({ availability: false, initial: data.old }));
+		hook.rerender({ availability: false, initial: data.new })
+
+		expect(hook.result.current[DATA]).toMatchObject(data.old);
+	});
+});
+
+describe('interval option', () => {
+	it('sets interval duration when mounted', async () => {
 		const setter = jest.spyOn(Sensors.Magnetometer, 'setUpdateInterval');
 
-		renderHook(() => useMagnetometer({ interval: 1500, availability: false }));
+		renderHook(() => useMagnetometer({ availability: false, interval: 1500 }));
 
 		expect(setter).toBeCalledWith(1500);
 	});
 
-	it('skips availability check', () => {
-		const checker = jest.spyOn(Sensors.Magnetometer, 'isAvailableAsync');
+	it('changes interval duration when rerendered', async () => {
+		const setter = jest.spyOn(Sensors.Magnetometer, 'setUpdateInterval');
 
-		renderHook(() => useMagnetometer({ availability: false }));
+		const hook = renderHook(useMagnetometer, { initialProps: { availability: false } });
+		hook.rerender({ availability: false, interval: 750 });
 
-		expect(checker).not.toBeCalled();
+		expect(setter).toBeCalledWith(750);
 	});
 });

--- a/packages/sensors/tests/use-pedometer-history.test.ts
+++ b/packages/sensors/tests/use-pedometer-history.test.ts
@@ -1,48 +1,106 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import * as Sensors from 'expo-sensors';
-import { usePedometerHistory } from '../src/use-pedometer-history';
+import { PedometerResult } from '../src/use-pedometer';
+import { usePedometerHistory, PedometerHistpryOptions } from '../src/use-pedometer-history';
 
 const DATA = 0;
 const AVAILABLE = 1;
 
-const start = new Date();
-const end = new Date(Number(start) + 5000);
+const fakeInput = (): Pick<PedometerHistpryOptions, 'start' | 'end'> => {
+	const limit = new Date('2016-01-01T12:00:00+00:00');
+	const start = new Date(limit.getTime() + (Date.now() - limit.getTime()) * Math.random());
+	const end = new Date(start.getTime() + (Date.now() - start.getTime()) * Math.random());
 
-it('returns data and availability when mounted', async () => {
-	const getter = jest.spyOn(Sensors.Pedometer, 'getStepCountAsync').mockResolvedValue({ steps: 1 });
+	return { start, end };
+};
 
-	const hook = renderHook(() => usePedometerHistory(start, end, { availability: false }));
-	await hook.waitForNextUpdate();
+const fakeData = (): PedometerResult => ({
+	steps: Math.round(1000 * Math.random()),
+});
 
-	expect(getter).toBeCalledWith(start, end);
-	expect(hook.result.current[DATA]).toMatchObject({ steps: 1 });
+it('returns default values when mounted', async () => {
+	const hook = renderHook(() => usePedometerHistory({ availability: false, ...fakeInput() }));
+
+	expect(hook.result.current[DATA]).toBeUndefined();
 	expect(hook.result.current[AVAILABLE]).toBeUndefined();
 });
 
-it('updates pedometer availability', async () => {
-	jest.spyOn(Sensors.Pedometer, 'isAvailableAsync').mockResolvedValue(true);
+describe('availability option', () => {
+	it('gets availability info when mounted', async () => {
+		jest.spyOn(Sensors.Pedometer, 'isAvailableAsync').mockResolvedValue(true);
 
-	const hook = renderHook(() => usePedometerHistory(start, end));
-	await hook.waitForNextUpdate();
+		const hook = renderHook(() => usePedometerHistory({ availability: true, ...fakeInput() }));
+		await hook.waitForNextUpdate();
 
-	expect(hook.result.current[AVAILABLE]).toBe(true);
-});
-
-describe('options', () => {
-	// todo: refactor fetching data async loop to avoid warnings
-	it('uses initial data', () => {
-		const initial = { steps: 10 };
-		const hook = renderHook(() => usePedometerHistory(start, end, { initial, availability: false }));
-
-		expect(hook.result.current[DATA]).toMatchObject(initial);
+		expect(hook.result.current[AVAILABLE]).toBe(true);
 	});
 
-	// todo: refactor fetching data async loop to avoid warnings
-	it('skips availability check', () => {
-		const checker = jest.spyOn(Sensors.Pedometer, 'isAvailableAsync');
+	it('gets availability when rerendered', async () => {
+		jest.spyOn(Sensors.Pedometer, 'isAvailableAsync').mockResolvedValue(true);
 
-		renderHook(() => usePedometerHistory(start, end, { availability: false }));
+		const hook = renderHook(usePedometerHistory, { initialProps: { availability: false, ...fakeInput() } });
+		hook.rerender({ availability: true, ...fakeInput() })
+		await hook.waitForNextUpdate();
 
-		expect(checker).not.toBeCalled();
+		expect(hook.result.current[AVAILABLE]).toBe(true);
+	});
+});
+
+describe('initial option', () => {
+	it('uses initial data when mounted', async () => {
+		const data = fakeData();
+		jest.spyOn(Sensors.Pedometer, 'getStepCountAsync').mockResolvedValue(fakeData());
+
+		const hook = renderHook(() => usePedometerHistory({ availability: false, initial: data, ...fakeInput() }));
+
+		expect(hook.result.current[DATA]).toMatchObject(data);
+
+		// note: to prevent updates on hook outside test loop, wait for the hook to update
+		await hook.waitForNextUpdate();
+	});
+
+	it('does not change initial data when rerendered', async () => {
+		const data = { old: fakeData(), new: fakeData() };
+		jest.spyOn(Sensors.Pedometer, 'getStepCountAsync').mockResolvedValue(data.old);
+
+		const hook = renderHook(() => usePedometerHistory({ availability: false, initial: data.old, ...fakeInput() }));
+		await act(() => {
+			hook.rerender({ availability: false, initial: data.new, ...fakeInput() });
+			return hook.waitForNextUpdate();
+		});
+
+		expect(hook.result.current[DATA]).toMatchObject(data.old);
+	});
+});
+
+describe('start and end options', () => {
+	it('uses data from date range when mounted', async () => {
+		const data = fakeData();
+		const input = fakeInput();
+		const getter = jest.spyOn(Sensors.Pedometer, 'getStepCountAsync').mockResolvedValue(data);
+
+		const hook = renderHook(() => usePedometerHistory({ availability: false, ...input }));
+		await hook.waitForNextUpdate();
+
+		expect(getter).toBeCalledWith(input.start, input.end);
+		expect(hook.result.current[DATA]).toBe(data);
+	});
+
+	it('changes data from new date range when rerendered', async () => {
+		const data = { old: fakeData(), new: fakeData() };
+		const input = { old: fakeInput(), new: fakeInput() };
+		const getter = jest.spyOn(Sensors.Pedometer, 'getStepCountAsync')
+			.mockResolvedValueOnce(data.old)
+			.mockResolvedValueOnce(data.new);
+
+		const hook = renderHook(usePedometerHistory, { initialProps: { availability: false, ...input.old } });
+		await hook.waitForNextUpdate();
+		await act(() => {
+			hook.rerender({ availability: false, ...input.new });
+			return hook.waitForNextUpdate();
+		});
+
+		expect(getter).toBeCalledWith(input.new.start, input.new.end);
+		expect(hook.result.current[DATA]).toBe(data.new);
 	});
 });

--- a/packages/sensors/tests/use-pedometer.test.ts
+++ b/packages/sensors/tests/use-pedometer.test.ts
@@ -1,39 +1,23 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import * as Sensors from 'expo-sensors';
-import { usePedometer } from '../src/use-pedometer';
+import { usePedometer, PedometerResult } from '../src/use-pedometer';
 
 const DATA = 0;
 const AVAILABLE = 1;
 
-it('returns data and availability when mounted', () => {
+const fakeData = (): PedometerResult => ({
+	steps: Math.round(1000 * Math.random()),
+});
+
+it('returns default values when mounted', async () => {
 	const hook = renderHook(() => usePedometer({ availability: false }));
 
 	expect(hook.result.current[DATA]).toBeUndefined();
 	expect(hook.result.current[AVAILABLE]).toBeUndefined();
 });
 
-it('updates pedometer availability', async () => {
-	jest.spyOn(Sensors.Pedometer, 'isAvailableAsync').mockResolvedValue(true);
-
-	const hook = renderHook(() => usePedometer());
-	await hook.waitForNextUpdate();
-
-	expect(hook.result.current[AVAILABLE]).toBe(true);
-});
-
-it('updates pedometer data', async () => {
-	const listener = jest.spyOn(Sensors.Pedometer, 'watchStepCount');
-	const data = { steps: 5 };
-
-	const hook = renderHook(() => usePedometer({ availability: false }));
-	const handler = listener.mock.calls[0][0];
-	act(() => handler(data));
-
-	expect(hook.result.current[DATA]).toMatchObject(data);
-});
-
-describe('event listener', () => {
-	it('subscribes when mounted', () => {
+describe('listener', () => {
+	it('subscribes when mounted', async () => {
 		const listener = jest.spyOn(Sensors.Pedometer, 'watchStepCount');
 
 		renderHook(() => usePedometer({ availability: false }));
@@ -41,7 +25,7 @@ describe('event listener', () => {
 		expect(listener).toBeCalled();
 	});
 
-	it('unsubscribes when unmounted', () => {
+	it('unsubscribes when unmounted', async () => {
 		const subscription = { remove: jest.fn() };
 		jest.spyOn(Sensors.Pedometer, 'watchStepCount').mockReturnValue(subscription);
 
@@ -50,21 +34,56 @@ describe('event listener', () => {
 
 		expect(subscription.remove).toBeCalled();
 	});
+
+	it('updates data from subscription', async () => {
+		const data = fakeData();
+		const listener = jest.spyOn(Sensors.Pedometer, 'watchStepCount');
+
+		const hook = renderHook(() => usePedometer({ availability: false }));
+		const handler = listener.mock.calls[0][0];
+		await act(() => {
+			handler(data);
+			return hook.waitForNextUpdate();
+		});
+
+		expect(hook.result.current[DATA]).toBe(data);
+	});
 });
 
-describe('options', () => {
-	it('uses initial data', () => {
-		const initial = { steps: 10 };
-		const hook = renderHook(() => usePedometer({ initial, availability: false }));
+describe('availability option', () => {
+	it('gets availability info when mounted', async () => {
+		jest.spyOn(Sensors.Pedometer, 'isAvailableAsync').mockResolvedValue(true);
 
-		expect(hook.result.current[DATA]).toMatchObject(initial);
+		const hook = renderHook(() => usePedometer({ availability: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[AVAILABLE]).toBe(true);
 	});
 
-	it('skips availability check', () => {
-		const checker = jest.spyOn(Sensors.Pedometer, 'isAvailableAsync');
+	it('gets availability when rerendered', async () => {
+		jest.spyOn(Sensors.Pedometer, 'isAvailableAsync').mockResolvedValue(true);
 
-		renderHook(() => usePedometer({ availability: false }));
+		const hook = renderHook(usePedometer, { initialProps: { availability: false } });
+		hook.rerender({ availability: true })
+		await hook.waitForNextUpdate();
 
-		expect(checker).not.toBeCalled();
+		expect(hook.result.current[AVAILABLE]).toBe(true);
+	});
+});
+
+describe('initial option', () => {
+	it('uses initial data when mounted', async () => {
+		const data = fakeData();
+		const hook = renderHook(() => usePedometer({ availability: false, initial: data }));
+
+		expect(hook.result.current[DATA]).toMatchObject(data);
+	});
+
+	it('does not change initial data when rerendered', async () => {
+		const data = { old: fakeData(), new: fakeData() };
+		const hook = renderHook(() => usePedometer({ availability: false, initial: data.old }));
+		hook.rerender({ availability: false, initial: data.new })
+
+		expect(hook.result.current[DATA]).toMatchObject(data.old);
 	});
 });


### PR DESCRIPTION
### Linked issue
This rewrites the tests for sensor hooks to keep it maintainable and test for misusage of variable dependencies. It should behave a bit better when changing the properties of the hooks.