### PR TITLE
refactor(example): separate history and live pedometer examples

### DIFF
--- a/example/src/molecules/sensors/index.ts
+++ b/example/src/molecules/sensors/index.ts
@@ -4,3 +4,4 @@ export * from './use-device-motion';
 export * from './use-gyroscope';
 export * from './use-magnetometer';
 export * from './use-pedometer';
+export * from './use-pedometer-history';

--- a/example/src/molecules/sensors/use-pedometer-history.tsx
+++ b/example/src/molecules/sensors/use-pedometer-history.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Caption } from 'react-native-paper';
+import { usePedometerHistory } from 'use-expo';
+import { Example, Information, Link, Measurement, Page } from '../../atoms';
+import { MoleculeProps } from '../../providers/molecule';
+import { docs } from '../../providers/urls';
+
+export const UsePedometerHistory: React.SFC<MoleculeProps> = (props) => {
+	const [history, available] = usePedometerHistory({
+		start: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
+		end: new Date(),
+	});
+
+	return (
+		<Page
+			title={props.name}
+			subtitle={props.description}
+		>
+			<Information>
+				This example fetches the "historical" steps count, within a date range,
+				from the <Link url={docs.pedometer}>Pedometer</Link> module.
+			</Information>
+			<Example>
+				<Caption>Last two weeks</Caption>
+				{!available && (
+					<Caption>Pedometer history is unavailable on this device</Caption>
+				)}
+				{(available && history) && (
+					<Measurement name='steps' value={history.steps} precision={0} />
+				)}
+			</Example>
+		</Page>
+	);
+};
+
+UsePedometerHistory.defaultProps = {
+	name: 'usePedometerHistory',
+	description: 'get historical step count',
+};

--- a/example/src/molecules/sensors/use-pedometer.tsx
+++ b/example/src/molecules/sensors/use-pedometer.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { Caption } from 'react-native-paper';
-import { usePedometer, usePedometerHistory } from 'use-expo';
+import { usePedometer } from 'use-expo';
 import { Example, Information, Link, Measurement, Page } from '../../atoms';
 import { MoleculeProps } from '../../providers/molecule';
 import { docs } from '../../providers/urls';
 
 export const UsePedometer: React.SFC<MoleculeProps> = (props) => {
-	const [live, liveAvailable] = usePedometer();
-	const [history, historyAvailable] = usePedometerHistory({
-		start: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
-		end: new Date(),
-	});
+	const [live, available] = usePedometer();
 
 	return (
 		<Page
@@ -18,24 +14,14 @@ export const UsePedometer: React.SFC<MoleculeProps> = (props) => {
 			subtitle={props.description}
 		>
 			<Information>
-				This example fetches the data from the <Link url={docs.pedometer}>Pedometer</Link> module.
-				It renders the current "live" steps as well as the fetched steps for the past week.
+				This example fetches the "live" steps count from the <Link url={docs.pedometer}>Pedometer</Link> module.
 			</Information>
 			<Example>
-				<Caption>Live</Caption>
-				{!liveAvailable && (
+				{!available && (
 					<Caption>Pedometer is unavailable on this device</Caption>
 				)}
-				{(liveAvailable && live) && (
+				{(available && live) && (
 					<Measurement name='steps' value={live.steps} precision={0} />
-				)}
-
-				<Caption>Last two weeks</Caption>
-				{!historyAvailable && (
-					<Caption>Pedometer history is unavailable on this device</Caption>
-				)}
-				{(historyAvailable && history) && (
-					<Measurement name='steps' value={history.steps} precision={0} />
 				)}
 			</Example>
 		</Page>
@@ -44,5 +30,5 @@ export const UsePedometer: React.SFC<MoleculeProps> = (props) => {
 
 UsePedometer.defaultProps = {
 	name: 'usePedometer',
-	description: 'tracks user step count',
+	description: 'tracks live step count',
 };


### PR DESCRIPTION
### Linked issue
Splitting them out shows developers better that these are separate hooks. You can either track live results, or fetch data that's already there. (or both, if you combine them 😄)
