### PR TITLE
refactor(brightness): reuse callbacks and docs to hooks

### DIFF
--- a/example/src/molecules/brightness/use-brightness.tsx
+++ b/example/src/molecules/brightness/use-brightness.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Slider } from 'react-native';
 import { Caption } from 'react-native-paper';
-import { round } from 'lodash';
+import { debounce, round } from 'lodash';
 import { useBrightness } from 'use-expo';
 import { Example, Information, Link, Page } from '../../atoms';
 import { MoleculeProps } from '../../providers/molecule';
@@ -9,6 +9,10 @@ import { docs } from '../../providers/urls';
 
 export const UseBrightness: React.SFC<MoleculeProps> = (props) => {
 	const [brightness, setBrightness] = useBrightness();
+	const setBrightnessDebounced = useCallback(
+		debounce(setBrightness, 100),
+		[setBrightness],
+	);
 
 	return (
 		<Page
@@ -24,7 +28,7 @@ export const UseBrightness: React.SFC<MoleculeProps> = (props) => {
 				<Slider
 					style={{ width: '100%' }}
 					value={brightness}
-					onValueChange={setBrightness}
+					onValueChange={setBrightnessDebounced}
 					step={0.001}
 					minimumValue={0.001}
 					maximumValue={1}

--- a/example/src/molecules/brightness/use-system-brightness.tsx
+++ b/example/src/molecules/brightness/use-system-brightness.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Slider } from 'react-native';
 import { Caption } from 'react-native-paper';
 import { SYSTEM_BRIGHTNESS } from 'expo-permissions';
 import { usePermissions, useSystemBrightness } from 'use-expo';
-import { round } from 'lodash';
+import { debounce, round } from 'lodash';
 import { Example, Information, Link, Page, MissingPermissions } from '../../atoms';
 import { MoleculeProps } from '../../providers/molecule';
 import { docs } from '../../providers/urls';
@@ -11,6 +11,10 @@ import { docs } from '../../providers/urls';
 export const UseSystemBrightness: React.SFC<MoleculeProps> = (props) => {
 	const [permission, askPermission] = usePermissions(SYSTEM_BRIGHTNESS);
 	const [brightness, setBrightness] = useSystemBrightness();
+	const setBrightnessDebounced = useCallback(
+		debounce(setBrightness, 100),
+		[setBrightness],
+	);
 
 	return (
 		<Page
@@ -33,7 +37,7 @@ export const UseSystemBrightness: React.SFC<MoleculeProps> = (props) => {
 						<Slider
 							style={{ width: '100%' }}
 							value={brightness}
-							onValueChange={setBrightness}
+							onValueChange={setBrightnessDebounced}
 							step={0.001}
 							minimumValue={0.001}
 							maximumValue={1}

--- a/packages/brightness/src/use-brightness.ts
+++ b/packages/brightness/src/use-brightness.ts
@@ -1,24 +1,35 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
 	getBrightnessAsync,
 	setBrightnessAsync,
 } from 'expo-brightness';
 
+/**
+ * Track, set or get the brightness of the device for the current app.
+ * It returns a number between `0..1`, which represents the brightness of the screen.
+ *
+ * Changing this does not change the brightness of the system.
+ * When the user exists the app, the brightness is reverted to the system brightness.
+ *
+ * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetbrightnessasync
+ */
 export function useBrightness(options: BrightnessOptions = {}): UseBrightnessSignature {
 	const [data, setData] = useState<number>();
 	const { get = true } = options;
 
-	function getBrightness() {
-		return getBrightnessAsync().then(setData);
-	}
+	const setBrightness = useCallback((brightness: number) => (
+		setBrightnessAsync(brightness).then(() => setData(brightness))
+	), [setData]);
 
-	function setBrightness(brightness: number) {
-		return setBrightnessAsync(brightness).then(() => setData(brightness));
-	}
+	const getBrightness = useCallback(() => (
+		getBrightnessAsync().then(setData)
+	), [setData]);
 
 	useEffect(() => {
-		if (get) getBrightness();
-	}, [get]);
+		if (get) {
+			getBrightness();
+		}
+	}, [get, getBrightness]);
 
 	return [data, setBrightness, getBrightness];
 }

--- a/packages/brightness/src/use-brightness.ts
+++ b/packages/brightness/src/use-brightness.ts
@@ -5,11 +5,11 @@ import {
 } from 'expo-brightness';
 
 /**
- * Track, set or get the brightness of the device for the current app.
+ * Track, set, or get the brightness of the device for the current app.
  * It returns a number between `0..1`, which represents the brightness of the screen.
  *
  * Changing this does not change the brightness of the system.
- * When the user exists the app, the brightness is reverted to the system brightness.
+ * When the user exits the app, the brightness reverts to the system's brightness.
  *
  * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetbrightnessasync
  */

--- a/packages/brightness/src/use-system-brightness-mode.ts
+++ b/packages/brightness/src/use-system-brightness-mode.ts
@@ -1,29 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
 	BrightnessMode,
 	getSystemBrightnessModeAsync,
 	setSystemBrightnessModeAsync,
 } from 'expo-brightness';
 
+/**
+ * Track, set or get the (global) system brightness mode of the device.
+ * It returns the `BrightnessMode` enum with one of the following values:
+ *   - 0 `UNKNOWN` current brightness mode cannot be determined
+ *   - 1 `AUTOMATIC` device OS will automatically adjust the screen brightness depending on the ambient light
+ *   - 2 `MANUAL` screen brightness will remain constant and will not be adjusted by the OS
+ *
+ * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
+ * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetsystembrightnessmodeasync
+ */
 export function useSystemBrightnessMode(
 	options: SystemBrightnessModeOptions = {}
 ): UseSystemBrightnessModeSignature {
 	const [data, setData] = useState<BrightnessMode>();
 	const { get = true } = options;
 
-	function getSystemBrightnessMode() {
-		return getSystemBrightnessModeAsync().then(setData);
-	}
+	const setSystemBrightnessMode = useCallback((mode: BrightnessMode) => (
+		setSystemBrightnessModeAsync(mode).then(() => setData(mode))
+	), []);
 
-	function setSystemBrightnessMode(mode: BrightnessMode) {
-		return setSystemBrightnessModeAsync(mode).then(() => setData(mode));
-	}
+	const getSystemBrightnessMode = useCallback(() => (
+		getSystemBrightnessModeAsync().then(setData)
+	), [setData]);
 
 	useEffect(() => {
 		if (get) {
 			getSystemBrightnessMode();
 		}
-	}, [get]);
+	}, [get, getSystemBrightnessMode]);
 
 	return [data, setSystemBrightnessMode, getSystemBrightnessMode];
 }

--- a/packages/brightness/src/use-system-brightness-mode.ts
+++ b/packages/brightness/src/use-system-brightness-mode.ts
@@ -6,11 +6,11 @@ import {
 } from 'expo-brightness';
 
 /**
- * Track, set or get the (global) system brightness mode of the device.
+ * Track, set, or get the (global) system brightness mode of the device.
  * It returns the `BrightnessMode` enum with one of the following values:
  *   - 0 `UNKNOWN` current brightness mode cannot be determined
  *   - 1 `AUTOMATIC` device OS will automatically adjust the screen brightness depending on the ambient light
- *   - 2 `MANUAL` screen brightness will remain constant and will not be adjusted by the OS
+ *   - 2 `MANUAL` device OS won't adjust screen brightness and will remain constant
  *
  * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
  * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetsystembrightnessmodeasync

--- a/packages/brightness/src/use-system-brightness.ts
+++ b/packages/brightness/src/use-system-brightness.ts
@@ -5,11 +5,11 @@ import {
 } from 'expo-brightness';
 
 /**
- * Track, set or get the (global) system brightness of the device.
+ * Track, set, or get the (global) system brightness of the device.
  * It returns a number between `0..1`, which represents the brightness of the screen.
  *
  * Changing this will modify the (global) system brightness.
- * When the user exists the app, the brightness doesn't change.
+ * When the user exits the app, the brightness doesn't change.
  *
  * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
  * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetsystembrightnessasync

--- a/packages/brightness/src/use-system-brightness.ts
+++ b/packages/brightness/src/use-system-brightness.ts
@@ -1,26 +1,36 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
 	getSystemBrightnessAsync,
 	setSystemBrightnessAsync,
 } from 'expo-brightness';
 
+/**
+ * Track, set or get the (global) system brightness of the device.
+ * It returns a number between `0..1`, which represents the brightness of the screen.
+ *
+ * Changing this will modify the (global) system brightness.
+ * When the user exists the app, the brightness doesn't change.
+ *
+ * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
+ * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetsystembrightnessasync
+ */
 export function useSystemBrightness(options: SystemBrightnessOptions = {}): UseSystemBrightnessSignature {
 	const [data, setData] = useState<number>();
 	const { get = true } = options;
 
-	function getSystemBrightness() {
-		return getSystemBrightnessAsync().then(setData);
-	}
+	const setSystemBrightness = useCallback((brightness: number) => (
+		setSystemBrightnessAsync(brightness).then(() => setData(brightness))
+	), [setData]);
 
-	function setSystemBrightness(brightness: number) {
-		return setSystemBrightnessAsync(brightness).then(() => setData(brightness));
-	}
+	const getSystemBrightness = useCallback(() => (
+		getSystemBrightnessAsync().then(setData)
+	), [setData]);
 
 	useEffect(() => {
 		if (get) {
 			getSystemBrightness();
 		}
-	}, [get]);
+	}, [get, getSystemBrightness]);
 
 	return [data, setSystemBrightness, getSystemBrightness];
 }

--- a/packages/brightness/tests/use-brightness.test.ts
+++ b/packages/brightness/tests/use-brightness.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import * as Brightness from 'expo-brightness';
-import { useBrightness } from '../src/use-brightness';
+import { useBrightness } from '../src';
 
 const DATA = 0
 const SET = 1;
@@ -14,28 +14,70 @@ it('returns data, set and get callbacks when mounted', async () => {
 	expect(hook.result.current[GET]).toBeInstanceOf(Function);
 });
 
-it('updates data with set callback', async () => {
-	const setter = jest.spyOn(Brightness, 'setBrightnessAsync').mockResolvedValue();
+describe('set callback', () => {
+	it('updates data with set callback', async () => {
+		const setter = jest.spyOn(Brightness, 'setBrightnessAsync')
+			.mockResolvedValue();
 
-	const hook = renderHook(() => useBrightness({ get: false }));
-	await act(() => hook.result.current[SET](0.5));
+		const hook = renderHook(() => useBrightness({ get: false }));
+		await act(() => hook.result.current[SET](0.5));
 
-	expect(setter).toBeCalledWith(0.5);
-	expect(hook.result.current[DATA]).toBe(0.5);
+		expect(setter).toBeCalledWith(0.5);
+		expect(hook.result.current[DATA]).toBe(0.5);
+	});
+
+	it('uses the same set callback when rerendered', async () => {
+		const hook = renderHook(() => useBrightness({ get: false }));
+		const setter = hook.result.current[SET];
+		hook.rerender();
+
+		expect(setter).toBe(hook.result.current[SET]);
+	});
 });
 
-it('updates data with get callback', async () => {
-	const getter = jest.spyOn(Brightness, 'getBrightnessAsync')
-		.mockResolvedValueOnce(1)
-		.mockResolvedValueOnce(0.5);
+describe('get callback', () => {
+	it('updates data with get callback', async () => {
+		jest.spyOn(Brightness, 'getBrightnessAsync')
+			.mockResolvedValue(1);
 
-	const hook = renderHook(() => useBrightness());
-	await hook.waitForNextUpdate();
+		const hook = renderHook(() => useBrightness({ get: false }));
+		expect(hook.result.current[DATA]).toBeUndefined();
+		await act(() => hook.result.current[GET]());
 
-	expect(hook.result.current[DATA]).toBe(1);
+		expect(hook.result.current[DATA]).toBe(1);
+	});
 
-	await act(() => hook.result.current[GET]());
+	it('uses the same get callback when rerendered', async () => {
+		const hook = renderHook(() => useBrightness({ get: false }));
+		const getter = hook.result.current[GET];
+		hook.rerender();
 
-	expect(getter).toBeCalledTimes(2);
-	expect(hook.result.current[DATA]).toBe(0.5);
+		expect(getter).toBe(hook.result.current[GET]);
+	});
+});
+
+describe('get option', () => {
+	it('updates data with get option when mounted', async () => {
+		jest.spyOn(Brightness, 'getBrightnessAsync')
+			.mockResolvedValue(1);
+
+		const hook = renderHook(() => useBrightness({ get: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[DATA]).toBe(1);
+	});
+
+	it('updates data with get option when rerendered', async () => {
+		jest.spyOn(Brightness, 'getBrightnessAsync')
+			.mockResolvedValue(0.75);
+
+		const hook = renderHook(useBrightness, {
+			initialProps: { get: false },
+		});
+		expect(hook.result.current[DATA]).toBeUndefined();
+		hook.rerender({ get: true });
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[DATA]).toBe(0.75);
+	});
 });

--- a/packages/brightness/tests/use-system-brightness-mode.test.ts
+++ b/packages/brightness/tests/use-system-brightness-mode.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import * as Brightness from 'expo-brightness';
-import { useSystemBrightnessMode } from '../src/use-system-brightness-mode';
+import { useSystemBrightnessMode } from '../src';
 
 const DATA = 0
 const SET = 1;
@@ -14,43 +14,67 @@ it('returns data, set and get callbacks when mounted', async () => {
 	expect(hook.result.current[GET]).toBeInstanceOf(Function);
 });
 
-it('updates data with set callback', async () => {
-	const setter = jest.spyOn(Brightness, 'setSystemBrightnessModeAsync').mockResolvedValue();
+describe('set callback', () => {
+	it('updates data with set callback', async () => {
+		const setter = jest.spyOn(Brightness, 'setSystemBrightnessModeAsync')
+			.mockResolvedValue();
 
-	const hook = renderHook(() => useSystemBrightnessMode({ get: false }));
-	await act(() => hook.result.current[SET](Brightness.BrightnessMode.AUTOMATIC));
+		const hook = renderHook(() => useSystemBrightnessMode({ get: false }));
+		await act(() => hook.result.current[SET](Brightness.BrightnessMode.AUTOMATIC));
 
-	expect(setter).toBeCalledWith(Brightness.BrightnessMode.AUTOMATIC);
-	expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.AUTOMATIC);
+		expect(setter).toBeCalledWith(Brightness.BrightnessMode.AUTOMATIC);
+		expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.AUTOMATIC);
+	});
+
+	it('uses the same set callback when rerendered', async () => {
+		const hook = renderHook(() => useSystemBrightnessMode({ get: false }));
+		const setter = hook.result.current[SET];
+		hook.rerender();
+
+		expect(setter).toBe(hook.result.current[SET]);
+	});
 });
 
-it('updates data with get callback', async () => {
-	const getter = jest.spyOn(Brightness, 'getSystemBrightnessModeAsync')
-		.mockResolvedValueOnce(Brightness.BrightnessMode.AUTOMATIC)
-		.mockResolvedValueOnce(Brightness.BrightnessMode.MANUAL);
+describe('get callback', () => {
+	it('updates data with get callback', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessModeAsync')
+			.mockResolvedValue(Brightness.BrightnessMode.AUTOMATIC);
 
-	const hook = renderHook(() => useSystemBrightnessMode());
-	await hook.waitForNextUpdate();
-
-	expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.AUTOMATIC);
-
-	await act(() => hook.result.current[GET]());
-
-	expect(getter).toBeCalledTimes(2);
-	expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.MANUAL);
-});
-
-describe('options', () => {
-	it('updates data with get callback, after initial render', async () => {
-		jest.spyOn(Brightness, 'getSystemBrightnessModeAsync').mockResolvedValue(Brightness.BrightnessMode.MANUAL);
-
-		const hook = renderHook(
-			props => useSystemBrightnessMode(props),
-			{ initialProps: { get: false } },
-		);
-
+		const hook = renderHook(() => useSystemBrightnessMode({ get: false }));
 		expect(hook.result.current[DATA]).toBeUndefined();
+		await act(() => hook.result.current[GET]());
 
+		expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.AUTOMATIC);
+	});
+
+	it('uses the same get callback when rerendered', async () => {
+		const hook = renderHook(() => useSystemBrightnessMode({ get: false }));
+		const getter = hook.result.current[SET];
+		hook.rerender();
+
+		expect(getter).toBe(hook.result.current[SET]);
+	});
+});
+
+describe('get option', () => {
+	it('updates data with get option when mounted', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessModeAsync')
+			.mockResolvedValue(Brightness.BrightnessMode.MANUAL);
+
+		const hook = renderHook(() => useSystemBrightnessMode({ get: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[DATA]).toBe(Brightness.BrightnessMode.MANUAL);
+	});
+
+	it('updates data with get option when rerendered', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessModeAsync')
+			.mockResolvedValue(Brightness.BrightnessMode.MANUAL);
+
+		const hook = renderHook(useSystemBrightnessMode, {
+			initialProps: { get: false },
+		});
+		expect(hook.result.current[DATA]).toBeUndefined();
 		hook.rerender({ get: true });
 		await hook.waitForNextUpdate();
 

--- a/packages/brightness/tests/use-system-brightness.test.ts
+++ b/packages/brightness/tests/use-system-brightness.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import * as Brightness from 'expo-brightness';
-import { useSystemBrightness } from '../src/use-system-brightness';
+import { useSystemBrightness } from '../src';
 
 const DATA = 0
 const SET = 1;
@@ -14,43 +14,67 @@ it('returns data, set and get callbacks when mounted', async () => {
 	expect(hook.result.current[GET]).toBeInstanceOf(Function);
 });
 
-it('updates data with set callback', async () => {
-	const setter = jest.spyOn(Brightness, 'setSystemBrightnessAsync').mockResolvedValue();
+describe('set callback', () => {
+	it('updates data with set callback', async () => {
+		const setter = jest.spyOn(Brightness, 'setSystemBrightnessAsync')
+			.mockResolvedValue();
 
-	const hook = renderHook(() => useSystemBrightness({ get: false }));
-	await act(() => hook.result.current[SET](0.5));
+		const hook = renderHook(() => useSystemBrightness({ get: false }));
+		await act(() => hook.result.current[SET](0.5));
 
-	expect(setter).toBeCalledWith(0.5);
-	expect(hook.result.current[DATA]).toBe(0.5);
+		expect(setter).toBeCalledWith(0.5);
+		expect(hook.result.current[DATA]).toBe(0.5);
+	});
+
+	it('uses the same set callback when rerendered', async () => {
+		const hook = renderHook(() => useSystemBrightness({ get: false }));
+		const setter = hook.result.current[SET];
+		hook.rerender();
+
+		expect(setter).toBe(hook.result.current[SET]);
+	});
 });
 
-it('updates data with get callback', async () => {
-	const getter = jest.spyOn(Brightness, 'getSystemBrightnessAsync')
-		.mockResolvedValueOnce(1)
-		.mockResolvedValueOnce(0.5);
+describe('get callback', () => {
+	it('updates data with get callback', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessAsync')
+			.mockResolvedValue(1)
 
-	const hook = renderHook(() => useSystemBrightness());
-	await hook.waitForNextUpdate();
-
-	expect(hook.result.current[DATA]).toBe(1);
-
-	await act(() => hook.result.current[GET]());
-
-	expect(getter).toBeCalledTimes(2);
-	expect(hook.result.current[DATA]).toBe(0.5);
-});
-
-describe('options', () => {
-	it('updates data with get callback, after initial render', async () => {
-		jest.spyOn(Brightness, 'getSystemBrightnessAsync').mockResolvedValue(0.75);
-
-		const hook = renderHook(
-			props => useSystemBrightness(props),
-			{ initialProps: { get: false } },
-		);
-
+		const hook = renderHook(() => useSystemBrightness());
 		expect(hook.result.current[DATA]).toBeUndefined();
+		await act(() => hook.result.current[GET]());
 
+		expect(hook.result.current[DATA]).toBe(1);
+	});
+
+	it('uses the same get callback when rerendered', async () => {
+		const hook = renderHook(() => useSystemBrightness({ get: false }));
+		const getter = hook.result.current[GET];
+		hook.rerender();
+
+		expect(getter).toBe(hook.result.current[GET]);
+	});
+});
+
+describe('get option', () => {
+	it('updates data with get option when mounted', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessAsync')
+			.mockResolvedValue(1);
+
+		const hook = renderHook(() => useSystemBrightness({ get: true }));
+		await hook.waitForNextUpdate();
+
+		expect(hook.result.current[DATA]).toBe(1);
+	});
+
+	it('updates data with get option when rerendered', async () => {
+		jest.spyOn(Brightness, 'getSystemBrightnessAsync')
+			.mockResolvedValue(0.75);
+
+		const hook = renderHook(useSystemBrightness,{
+			initialProps: { get: false },
+		});
+		expect(hook.result.current[DATA]).toBeUndefined();
 		hook.rerender({ get: true });
 		await hook.waitForNextUpdate();
 


### PR DESCRIPTION
### Linked issue
This improves the DX, test coverage, and performance of the brightness hooks.