### PR TITLE
docs(battery): use code annotation in state enum

### DIFF
--- a/packages/battery/src/use-battery-state.ts
+++ b/packages/battery/src/use-battery-state.ts
@@ -4,10 +4,10 @@ import { BatteryState, getBatteryStateAsync, addBatteryStateListener } from 'exp
 /**
  * Get or track the battery state of the device.
  * It returns the `BatteryState` enum with one of the following values:
- *   - 0 (UNKNOWN), if the battery state is unknown or unable to access
- *   - 1 (UNPLUGGED), if the battery is not charging or discharging
- *   - 2 (CHARGING), if the battery is charging
- *   - 3 (FULL), if the battery level is full
+ *   - 0 `UNKNOWN` if the battery state is unknown or unable to access
+ *   - 1 `UNPLUGGED` if the battery is not charging or discharging
+ *   - 2 `CHARGING` if the battery is charging
+ *   - 3 `FULL` if the battery level is full
  *
  * @see https://docs.expo.io/versions/latest/sdk/battery/#batterygetbatterystateasync
  */


### PR DESCRIPTION
### Linked issue
It matches the new brightness annotation, and should mark the enum names a bit better.