### PR TITLE
refactor(permissions): add docs and update rerendering performance

### DIFF
--- a/example/src/atoms/missing-permissions.tsx
+++ b/example/src/atoms/missing-permissions.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
+import { Linking } from 'react-native';
 import { Button, Caption } from 'react-native-paper';
 import { Space } from './space';
 
 export const MissingPermissions: React.SFC<MissingPermissionsProps> = (props) => (
 	<>
 		<Space bottom>
-			<Caption>{props.children}</Caption>
+			<Caption style={{ textAlign: 'center' }}>{props.children}</Caption>
 		</Space>
-		<Button onPress={props.onConfirm} mode='outlined' color='#333'>
-			Give permission
-		</Button>
+
+		{(props.canConfirm && props.onConfirm)
+			? <Button onPress={props.onConfirm} mode='outlined' color='#333'>Give permission</Button>
+			: <Button onPress={Linking.openSettings} mode='outlined' color='#333'>Open app settings</Button>
+		}
 	</>
 );
 
 export interface MissingPermissionsProps {
 	/** Some information which permissions and why they are necessary. */
 	children: React.ReactNode;
-	/** A callback invoked when the user wants to grant the permission(s). */
-	onConfirm: () => any;
+	/** Determine if a user can give the permission using the `onConfirm` callback (defaults to `true`) */
+	canConfirm?: boolean;
+	/** A callback invoked when the user wants to grant the permission(s), if possible */
+	onConfirm?: () => any;
 }
+
+MissingPermissions.defaultProps = {
+	canConfirm: true,
+};

--- a/example/src/molecules/permissions/use-permissions.tsx
+++ b/example/src/molecules/permissions/use-permissions.tsx
@@ -21,12 +21,12 @@ export const UsePermissions: React.SFC<MoleculeProps> = (props) => {
 				When you grant the <Link url={url.permissions.camera}>CAMERA</Link> permission, it renders a simple camera with a text overlay.
 			</Information>
 			<Example space={false}>
-				{(permission && permission.status !== 'granted') && (
-					<MissingPermissions onConfirm={askPermission}>
+				{(permission?.status !== 'granted') && (
+					<MissingPermissions canConfirm={permission?.canAskAgain} onConfirm={askPermission}>
 						We need permission to use the camera.
 					</MissingPermissions>
 				)}
-				{(permission && permission.status === 'granted') && (
+				{(permission?.status === 'granted') && (
 					<Camera
 						style={styles.camera}
 						type={CameraConstants.Type.front}

--- a/packages/permissions/src/use-permissions.ts
+++ b/packages/permissions/src/use-permissions.ts
@@ -6,6 +6,16 @@ import {
 	getAsync,
 } from 'expo-permissions';
 
+/**
+ * Get or ask permission for protected functionality within the app.
+ * It returns the permission response after fetching or asking it.
+ * The hook fetches the permissions when rendered, by default.
+ * To ask the user permission, use the `askPermission` callback or `ask` option.
+ *
+ * @see https://docs.expo.io/versions/latest/sdk/permissions/
+ * @example
+ * const [permission, askPermission, getPermission] = usePermissions(...);
+ */
 export function usePermissions(
 	type: PermissionType | PermissionType[],
 	options: PermissionsOptions = {},
@@ -17,15 +27,17 @@ export function usePermissions(
 		get = true,
 	} = options;
 
-	const askPermissions = useCallback(
-		() => askAsync(...types).then(setData),
-		[types],
-	);
+	// note: its intentional to listen to `type`, not `types`.
+	// when `type` is casted to an array, it possible creates a new one on every render.
+	// to prevent unnecessary function instances we need to listen to the "raw" value.
 
-	const getPermissions = useCallback(
-		() => getAsync(...types).then(setData),
-		[types],
-	);
+	const askPermissions = useCallback(() => (
+		askAsync(...types).then(setData)
+	), [type]); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const getPermissions = useCallback(() => (
+		getAsync(...types).then(setData)
+	), [type]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		if (ask) {


### PR DESCRIPTION
### Linked issue
This should improve DX with docs and performance by not-initiating new ask/get callbacks for single permissions.