### PR TITLE
refactor: use inline return types for better visibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
 		// fix: temporary use the "normal" indent until the typescript version rewrite is complete
 		// see: https://github.com/typescript-eslint/typescript-eslint/milestone/1
 		// '@typescript-eslint/indent': ['error', 'tab'],
-		'indent': ['error', 'tab'],
+		'indent': ['error', 'tab', { SwitchCase: 1 }],
 	},
 	settings: {
 		react: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,6 @@ module.exports = {
 	rules: {
 		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
-		'@typescript-eslint/indent': ['error', 'tab'],
 		'@typescript-eslint/no-explicit-any': 'off',
 		'@typescript-eslint/no-non-null-assertion': 'off',
 		'@typescript-eslint/no-use-before-define': 'off',
@@ -25,6 +24,11 @@ module.exports = {
 		'react-hooks/rules-of-hooks': 'error',
 		'react/no-unescaped-entities': 'off',
 		'react/prop-types': 'off',
+
+		// fix: temporary use the "normal" indent until the typescript version rewrite is complete
+		// see: https://github.com/typescript-eslint/typescript-eslint/milestone/1
+		// '@typescript-eslint/indent': ['error', 'tab'],
+		'indent': ['error', 'tab'],
 	},
 	settings: {
 		react: {

--- a/packages/battery/src/use-battery-level.ts
+++ b/packages/battery/src/use-battery-level.ts
@@ -4,11 +4,17 @@ import { getBatteryLevelAsync, addBatteryLevelListener } from 'expo-battery';
 /**
  * Get or track the battery level of the device.
  * It returns a number between `0..1`, which represents the percentage of power left.
- * When the device doesn't provide this, it returns `-1`.
  *
  * @see https://docs.expo.io/versions/latest/sdk/battery/#batterygetbatterylevelasync
+ * @remarks For older devices without this feature, it always returns `-1`.
+ * @example const [batteryLevel, getBatteryLevel] = useBatteryLevel(...);
  */
-export function useBatteryLevel(options: BatteryLevelOptions = {}): UseBatteryLevelSignature {
+export function useBatteryLevel(
+	options: BatteryLevelOptions = {},
+): [
+	number | undefined,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<number>();
 	const {
 		get = true,
@@ -31,11 +37,6 @@ export function useBatteryLevel(options: BatteryLevelOptions = {}): UseBatteryLe
 
 	return [data, getBatteryLevel];
 }
-
-type UseBatteryLevelSignature = [
-	number | undefined,
-	() => Promise<void>,
-];
 
 export interface BatteryLevelOptions {
 	/** If it should fetch the battery level when mounted, defaults to `true` */

--- a/packages/battery/src/use-battery-low-power-mode.ts
+++ b/packages/battery/src/use-battery-low-power-mode.ts
@@ -5,13 +5,17 @@ import { isLowPowerModeEnabledAsync, addLowPowerModeListener } from 'expo-batter
  * Get or track the low power mode of the device.
  * It returns `true` when enabled, or `false` when disabled.
  * This feature is also known as battery save mode.
- * For older devices without this feature, it always returns `false`.
  *
  * @see https://docs.expo.io/versions/latest/sdk/battery/#batteryislowpowermodeenabledasync
+ * @remarks For older devices without this feature, it always returns `false`.
+ * @example const [isLowPowerMode, getLowPowerMode] = useBatteryLowPowerMode(...);
  */
 export function useBatteryLowPowerMode(
-	options: BatteryLowPowerModeOptions = {}
-): UseBatteryLowPowerModeSignature {
+	options: BatteryLowPowerModeOptions = {},
+): [
+	boolean | undefined,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<boolean>();
 	const {
 		get = true,
@@ -34,11 +38,6 @@ export function useBatteryLowPowerMode(
 
 	return [data, getBatteryLowPowerMode];
 }
-
-type UseBatteryLowPowerModeSignature = [
-	boolean | undefined,
-	() => Promise<void>,
-];
 
 export interface BatteryLowPowerModeOptions {
 	/** If it should fetch the battery low power mode status when mounted, defaults to `true` */

--- a/packages/battery/src/use-battery-state.ts
+++ b/packages/battery/src/use-battery-state.ts
@@ -10,8 +10,14 @@ import { BatteryState, getBatteryStateAsync, addBatteryStateListener } from 'exp
  *   - 3 `FULL` if the battery level is full
  *
  * @see https://docs.expo.io/versions/latest/sdk/battery/#batterygetbatterystateasync
+ * @example const [batteryState, getBatteryState] = useBatteryState(...);
  */
-export function useBatteryState(options: BatteryStateOptions = {}): UseBatteryStateSignature {
+export function useBatteryState(
+	options: BatteryStateOptions = {}
+): [
+	BatteryState | undefined,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<BatteryState>();
 	const {
 		get = true,
@@ -34,11 +40,6 @@ export function useBatteryState(options: BatteryStateOptions = {}): UseBatterySt
 
 	return [data, getBatteryState];
 }
-
-type UseBatteryStateSignature = [
-	BatteryState | undefined,
-	() => Promise<void>,
-];
 
 export interface BatteryStateOptions {
 	/** If it should fetch the battery state when mounted, defaults to `true` */

--- a/packages/battery/src/use-battery.ts
+++ b/packages/battery/src/use-battery.ts
@@ -8,11 +8,16 @@ import { PowerState, getPowerStateAsync } from 'expo-battery';
  *   - current battery state (e.g., charging or unplugged)
  *   - if low power mode is turned on (a.k.a battery saver)
  *
- * Note, this does not track "live" updates of these values.
- *
  * @see https://docs.expo.io/versions/latest/sdk/battery/#batterygetpowerstateasync
+ * @remarks This does not track "live" updates of these values.
+ * @example const [powerState, getPowerState] = useBattery(...);
  */
-export function useBattery(options: BatteryOptions = {}): UseBatterySignature {
+export function useBattery(
+	options: BatteryOptions = {},
+): [
+	PowerState | undefined,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<PowerState>();
 	const { get = true } = options;
 
@@ -28,11 +33,6 @@ export function useBattery(options: BatteryOptions = {}): UseBatterySignature {
 
 	return [data, getBatteryPowerState];
 }
-
-type UseBatterySignature = [
-	PowerState | undefined,
-	() => Promise<void>,
-];
 
 export interface BatteryOptions {
 	/** If it should fetch the battery power state when mounted, defaults to `true` */

--- a/packages/brightness/src/use-brightness.ts
+++ b/packages/brightness/src/use-brightness.ts
@@ -1,19 +1,21 @@
-import { useEffect, useState, useCallback } from 'react';
-import {
-	getBrightnessAsync,
-	setBrightnessAsync,
-} from 'expo-brightness';
+import { useCallback, useEffect, useState } from 'react';
+import { getBrightnessAsync, setBrightnessAsync } from 'expo-brightness';
 
 /**
  * Track, set, or get the brightness of the device for the current app.
  * It returns a number between `0..1`, which represents the brightness of the screen.
  *
- * Changing this does not change the brightness of the system.
- * When the user exits the app, the brightness reverts to the system's brightness.
- *
  * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetbrightnessasync
+ * @remarks This does not change the system brightness, and will revert when exiting the app.
+ * @example const [brightness, setBrightness, getBrightness] = useBrightness(...);
  */
-export function useBrightness(options: BrightnessOptions = {}): UseBrightnessSignature {
+export function useBrightness(
+	options: BrightnessOptions = {},
+): [
+	number | undefined,
+	(brightness: number) => Promise<void>,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<number>();
 	const { get = true } = options;
 
@@ -33,12 +35,6 @@ export function useBrightness(options: BrightnessOptions = {}): UseBrightnessSig
 
 	return [data, setBrightness, getBrightness];
 }
-
-type UseBrightnessSignature = [
-	number | undefined,
-	(brightness: number) => Promise<void>,
-	() => Promise<void>,
-];
 
 export interface BrightnessOptions {
 	/** If it should fetch the brightness when mounted, defaults to `true` */

--- a/packages/brightness/src/use-system-brightness-mode.ts
+++ b/packages/brightness/src/use-system-brightness-mode.ts
@@ -1,9 +1,5 @@
-import { useEffect, useState, useCallback } from 'react';
-import {
-	BrightnessMode,
-	getSystemBrightnessModeAsync,
-	setSystemBrightnessModeAsync,
-} from 'expo-brightness';
+import { useCallback, useEffect, useState } from 'react';
+import { BrightnessMode, getSystemBrightnessModeAsync, setSystemBrightnessModeAsync } from 'expo-brightness';
 
 /**
  * Track, set, or get the (global) system brightness mode of the device.
@@ -12,12 +8,17 @@ import {
  *   - 1 `AUTOMATIC` device OS will automatically adjust the screen brightness depending on the ambient light
  *   - 2 `MANUAL` device OS won't adjust screen brightness and will remain constant
  *
- * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
  * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetsystembrightnessmodeasync
+ * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
+ * @example const [brightnessMode, setBrightnessMode, getBrightnessMode] = useSystemBrightnessMode(...);
  */
 export function useSystemBrightnessMode(
 	options: SystemBrightnessModeOptions = {}
-): UseSystemBrightnessModeSignature {
+): [
+	BrightnessMode | undefined,
+	(brightness: BrightnessMode) => Promise<void>,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<BrightnessMode>();
 	const { get = true } = options;
 
@@ -37,12 +38,6 @@ export function useSystemBrightnessMode(
 
 	return [data, setSystemBrightnessMode, getSystemBrightnessMode];
 }
-
-type UseSystemBrightnessModeSignature = [
-	BrightnessMode | undefined,
-	(brightness: BrightnessMode) => Promise<void>,
-	() => Promise<void>,
-];
 
 export interface SystemBrightnessModeOptions {
 	/** If it should fetch the brightness mode when mounted, defaults to `true` */

--- a/packages/brightness/src/use-system-brightness.ts
+++ b/packages/brightness/src/use-system-brightness.ts
@@ -1,8 +1,5 @@
-import { useEffect, useState, useCallback } from 'react';
-import {
-	getSystemBrightnessAsync,
-	setSystemBrightnessAsync,
-} from 'expo-brightness';
+import { useCallback, useEffect, useState } from 'react';
+import { getSystemBrightnessAsync, setSystemBrightnessAsync } from 'expo-brightness';
 
 /**
  * Track, set, or get the (global) system brightness of the device.
@@ -11,10 +8,18 @@ import {
  * Changing this will modify the (global) system brightness.
  * When the user exits the app, the brightness doesn't change.
  *
- * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
  * @see https://docs.expo.io/versions/latest/sdk/brightness/#brightnessgetsystembrightnessasync
+ * @remarks The set callback requires the `SYSTEM_BRIGHTNESS` permission.
+ * @remarks This changes the system brightness, and will remain when exiting the app.
+ * @example const [brightness, setBrightness, getBrightness] = useSystemBrightness(...);
  */
-export function useSystemBrightness(options: SystemBrightnessOptions = {}): UseSystemBrightnessSignature {
+export function useSystemBrightness(
+	options: SystemBrightnessOptions = {}
+): [
+	number | undefined,
+	(brightness: number) => Promise<void>,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<number>();
 	const { get = true } = options;
 
@@ -34,12 +39,6 @@ export function useSystemBrightness(options: SystemBrightnessOptions = {}): UseS
 
 	return [data, setSystemBrightness, getSystemBrightness];
 }
-
-type UseSystemBrightnessSignature = [
-	number | undefined,
-	(brightness: number) => Promise<void>,
-	() => Promise<void>,
-];
 
 export interface SystemBrightnessOptions {
 	/** If it should fetch the system brightness when mounted, defaults to `true` */

--- a/packages/font/src/use-fonts.ts
+++ b/packages/font/src/use-fonts.ts
@@ -1,17 +1,15 @@
 import { useEffect, useState } from 'react';
-import { Asset } from 'expo-asset';
-import { loadAsync } from 'expo-font';
+import { FontSource, loadAsync } from 'expo-font';
 
 /**
  * Load a map of custom fonts to use in textual elements.
  * The map keys are used as font names, and can be used with `fontFamily: <name>;`.
- * It returns a boolean stating if all fonts are loaded.
+ * It returns a boolean describing if all fonts are loaded.
  *
  * @see https://docs.expo.io/versions/latest/sdk/font/
- * @example
- * const [loaded] = useFonts({ ... });
+ * @example const [isLoaded] = useFonts(...);
  */
-export function useFonts(map: FontMap): UseFontsSignature {
+export function useFonts(map: FontMap): [boolean] {
 	const [loaded, setLoaded] = useState(false);
 
 	useEffect(() => {
@@ -25,6 +23,3 @@ export function useFonts(map: FontMap): UseFontsSignature {
 interface FontMap {
 	[name: string]: FontSource;
 }
-
-type FontSource = string | number | Asset;
-type UseFontsSignature = [boolean];

--- a/packages/permissions/src/use-permissions.ts
+++ b/packages/permissions/src/use-permissions.ts
@@ -1,10 +1,5 @@
-import { useEffect, useState, useCallback } from 'react';
-import {
-	PermissionType,
-	PermissionResponse,
-	askAsync,
-	getAsync,
-} from 'expo-permissions';
+import { useCallback, useEffect, useState } from 'react';
+import { PermissionType, PermissionResponse, askAsync, getAsync } from 'expo-permissions';
 
 /**
  * Get or ask permission for protected functionality within the app.
@@ -13,13 +8,16 @@ import {
  * To ask the user permission, use the `askPermission` callback or `ask` option.
  *
  * @see https://docs.expo.io/versions/latest/sdk/permissions/
- * @example
- * const [permission, askPermission, getPermission] = usePermissions(...);
+ * @example const [permission, askPermission, getPermission] = usePermissions(...);
  */
 export function usePermissions(
 	type: PermissionType | PermissionType[],
 	options: PermissionsOptions = {},
-): UsePermissionsSignature {
+): [
+	PermissionResponse | undefined,
+	() => Promise<void>,
+	() => Promise<void>,
+] {
 	const [data, setData] = useState<PermissionResponse>();
 	const types = Array.isArray(type) ? type : [type];
 	const {
@@ -51,12 +49,6 @@ export function usePermissions(
 
 	return [data, askPermissions, getPermissions];
 }
-
-type UsePermissionsSignature = [
-	PermissionResponse | undefined,
-	() => Promise<void>,
-	() => Promise<void>,
-];
 
 export interface PermissionsOptions {
 	/** If it should ask the permissions when mounted, defaults to `false` */

--- a/packages/screen-orientation/src/use-screen-orientation-lock.ts
+++ b/packages/screen-orientation/src/use-screen-orientation-lock.ts
@@ -7,8 +7,7 @@ import { ScreenOrientation } from 'expo';
  * This hook is similar to the `useKeepAwake` hook and does not return anything.
  *
  * @see https://docs.expo.io/versions/latest/sdk/screen-orientation/
- * @example
- * useScreenOrientationLock(...);
+ * @example useScreenOrientationLock(...);
  */
 export function useScreenOrientationLock(orientation: ScreenOrientation.OrientationLock): void {
 	useEffect(() => {

--- a/packages/screen-orientation/src/use-screen-orientation.ts
+++ b/packages/screen-orientation/src/use-screen-orientation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ScreenOrientation } from 'expo';
 
 /**
@@ -7,12 +7,15 @@ import { ScreenOrientation } from 'expo';
  * For iOS, it also returns both the horizontal and vertical size classes.
  *
  * @see https://docs.expo.io/versions/latest/sdk/screen-orientation/
- * @example
- * const [orientation, sizeClass] = useScreenOrientation(...);
+ * @example const [orientation, sizeClass, getScreenOrientation] = useScreenOrientation(...);
  */
 export function useScreenOrientation(
 	options: ScreenOrientationOptions = {},
-): UseScreenOrientationSignature {
+): [
+	ScreenOrientation.Orientation | undefined,
+	ScreenOrientationSizeClass | undefined,
+	() => Promise<void>,
+] {
 	const [orientation, setOrientation] = useState<ScreenOrientation.Orientation>();
 	const [sizeClass, setSizeClass] = useState<ScreenOrientationSizeClass>();
 	const {
@@ -52,12 +55,6 @@ export function useScreenOrientation(
 
 	return [orientation, sizeClass, getScreenOrientation];
 }
-
-type UseScreenOrientationSignature = [
-	ScreenOrientation.Orientation | undefined,
-	ScreenOrientationSizeClass | undefined,
-	() => Promise<void>,
-];
 
 export interface ScreenOrientationOptions {
 	/** If it should fetch the screen orientation when mounted, defaults to `true` */

--- a/packages/sensors/src/use-accelerometer.ts
+++ b/packages/sensors/src/use-accelerometer.ts
@@ -10,7 +10,12 @@ import { Accelerometer, ThreeAxisMeasurement } from 'expo-sensors';
  * @remarks Changing the update interval will affect all accelerometer listeners.
  * @example const [data, isAvailable] = useAccelerometer(...);
  */
-export function useAccelerometer(options: AccelerometerOptions = {}): UseAccelerometerSignature {
+export function useAccelerometer(
+	options: AccelerometerOptions = {}
+): [
+	ThreeAxisMeasurement | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -33,16 +38,12 @@ export function useAccelerometer(options: AccelerometerOptions = {}): UseAcceler
 	return [data, available];
 }
 
-type UseAccelerometerSignature = [
-	ThreeAxisMeasurement | undefined,
-	boolean | undefined,
-];
-
 export interface AccelerometerOptions {
 	/** The initial data to use before the first update. */
 	initial?: ThreeAxisMeasurement;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
+
 	/**
 	 * The interval, in ms, to update the accelerometer data.
 	 * Note, this is set globally through `Accelerometer.setUpdateInterval`.

--- a/packages/sensors/src/use-barometer.ts
+++ b/packages/sensors/src/use-barometer.ts
@@ -10,7 +10,12 @@ import { Barometer, BarometerMeasurement } from 'expo-sensors';
  * @remarks Changing the update interval will affect all barometer listeners.
  * @example const [data, isAvailable] = useBarometer(...);
  */
-export function useBarometer(options: BarometerOptions = {}): UseBarometerSignature {
+export function useBarometer(
+	options: BarometerOptions = {}
+): [
+	BarometerMeasurement | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -33,16 +38,12 @@ export function useBarometer(options: BarometerOptions = {}): UseBarometerSignat
 	return [data, available];
 }
 
-type UseBarometerSignature = [
-	BarometerMeasurement | undefined,
-	boolean | undefined,
-];
-
 export interface BarometerOptions {
 	/** The initial data to use before the first update. */
 	initial?: BarometerMeasurement;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
+
 	/**
 	 * The interval, in ms, to update the barometer data.
 	 * Note, this is set globally through `Barometer.setUpdateInterval`.

--- a/packages/sensors/src/use-device-motion.ts
+++ b/packages/sensors/src/use-device-motion.ts
@@ -10,7 +10,12 @@ import { DeviceMotion, DeviceMotionMeasurement } from 'expo-sensors';
  * @remarks Changing the update interval will affect all device motion listeners.
  * @example const [data, isAvailable] = useDeviceMotion(...);
  */
-export function useDeviceMotion(options: DeviceMotionOptions = {}): UseDeviceMotionSignature {
+export function useDeviceMotion(
+	options: DeviceMotionOptions = {}
+): [
+	DeviceMotionMeasurement | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -33,16 +38,12 @@ export function useDeviceMotion(options: DeviceMotionOptions = {}): UseDeviceMot
 	return [data, available];
 }
 
-type UseDeviceMotionSignature = [
-	DeviceMotionMeasurement | undefined,
-	boolean | undefined,
-];
-
 export interface DeviceMotionOptions {
 	/** The initial data to use before the first update. */
 	initial?: DeviceMotionMeasurement;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
+
 	/**
 	 * The interval, in ms, to update the device motion data.
 	 * Note, this is set globally through `DeviceMotion.setUpdateInterval`.

--- a/packages/sensors/src/use-gyroscope.ts
+++ b/packages/sensors/src/use-gyroscope.ts
@@ -10,7 +10,12 @@ import { Gyroscope, ThreeAxisMeasurement } from 'expo-sensors';
  * @remarks Changing the update interval will affect all gyroscope listeners.
  * @example const [data, isAvailable] = useGyroscope(...);
  */
-export function useGyroscope(options: GyroscopeOptions = {}): UseGyroscopeSignature {
+export function useGyroscope(
+	options: GyroscopeOptions = {}
+): [
+	ThreeAxisMeasurement | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -33,16 +38,12 @@ export function useGyroscope(options: GyroscopeOptions = {}): UseGyroscopeSignat
 	return [data, available];
 }
 
-type UseGyroscopeSignature = [
-	ThreeAxisMeasurement | undefined,
-	boolean | undefined,
-];
-
 export interface GyroscopeOptions {
 	/** The initial data to use before the first update. */
 	initial?: ThreeAxisMeasurement;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
+
 	/**
 	 * The interval, in ms, to update the gyroscope data.
 	 * Note, this is set globally through `Gyroscope.setUpdateInterval`.

--- a/packages/sensors/src/use-magnetometer-uncalibrated.ts
+++ b/packages/sensors/src/use-magnetometer-uncalibrated.ts
@@ -12,7 +12,10 @@ import { MagnetometerUncalibrated, ThreeAxisMeasurement } from 'expo-sensors';
  */
 export function useMagnetometerUncalibrated(
 	options: MagnetometerUncalibratedOptions = {}
-): UseMagnetometerUncalibratedSignature {
+): [
+	ThreeAxisMeasurement | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -35,16 +38,12 @@ export function useMagnetometerUncalibrated(
 	return [data, available];
 }
 
-type UseMagnetometerUncalibratedSignature = [
-	ThreeAxisMeasurement | undefined,
-	boolean | undefined,
-];
-
 export interface MagnetometerUncalibratedOptions {
 	/** The initial data to use before the first update. */
 	initial?: ThreeAxisMeasurement;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
+
 	/**
 	 * The interval, in ms, to update the uncalibrated magnetometer data.
 	 * Note, this is set globally through `MagnetometerUncalibrated.setUpdateInterval`.

--- a/packages/sensors/src/use-magnetometer.ts
+++ b/packages/sensors/src/use-magnetometer.ts
@@ -10,7 +10,12 @@ import { Magnetometer, ThreeAxisMeasurement } from 'expo-sensors';
  * @remarks Changing the update interval will affect all magnetometer listeners.
  * @example const [data, isAvailable] = useMagnetometer(...);
  */
-export function useMagnetometer(options: MagnetometerOptions = {}): UseMagnetometerSignature {
+export function useMagnetometer(
+	options: MagnetometerOptions = {}
+): [
+	ThreeAxisMeasurement | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -33,16 +38,12 @@ export function useMagnetometer(options: MagnetometerOptions = {}): UseMagnetome
 	return [data, available];
 }
 
-type UseMagnetometerSignature = [
-	ThreeAxisMeasurement | undefined,
-	boolean | undefined,
-];
-
 export interface MagnetometerOptions {
 	/** The initial data to use before the first update. */
 	initial?: ThreeAxisMeasurement;
 	/** If it should check the availability of the sensor, defaults to `true`. */
 	availability?: boolean;
+
 	/**
 	 * The interval, in ms, to update the magnetometer data.
 	 * Note, this is set globally through `Magnetometer.setUpdateInterval`.

--- a/packages/sensors/src/use-pedometer-history.ts
+++ b/packages/sensors/src/use-pedometer-history.ts
@@ -10,7 +10,12 @@ import { PedometerResult, PedometerOptions } from './use-pedometer';
  * @remarks iOS only returns the last 7 days.
  * @example const [data, isAvailable] = usePedometerHistory(...);
  */
-export function usePedometerHistory(options: PedometerHistpryOptions): UsePedometerHistorySignature {
+export function usePedometerHistory(
+	options: PedometerHistpryOptions
+): [
+	PedometerResult | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const {
@@ -29,11 +34,6 @@ export function usePedometerHistory(options: PedometerHistpryOptions): UsePedome
 
 	return [data, available];
 }
-
-type UsePedometerHistorySignature = [
-	PedometerResult | undefined,
-	boolean | undefined,
-];
 
 export interface PedometerHistpryOptions extends PedometerOptions {
 	/**

--- a/packages/sensors/src/use-pedometer.ts
+++ b/packages/sensors/src/use-pedometer.ts
@@ -8,7 +8,12 @@ import { Pedometer } from 'expo-sensors';
  * @see https://docs.expo.io/versions/latest/sdk/pedometer/
  * @example const [data, isAvailable] = usePedometer(...);
  */
-export function usePedometer(options: PedometerOptions = {}): UsePedometerSignature {
+export function usePedometer(
+	options: PedometerOptions = {}
+): [
+	PedometerResult | undefined,
+	boolean | undefined,
+] {
 	const [data, setData] = useState(options.initial);
 	const [available, setAvailable] = useState<boolean>();
 	const { availability = true } = options;
@@ -23,11 +28,6 @@ export function usePedometer(options: PedometerOptions = {}): UsePedometerSignat
 
 	return [data, available];
 }
-
-type UsePedometerSignature = [
-	PedometerResult | undefined,
-	boolean | undefined,
-];
 
 // note: this isn't exported from expo, so we need to duplicate it
 export interface PedometerResult {


### PR DESCRIPTION
### Linked issue
Its now visible when hovering over the hook in e.g. vscode. That makes it a bit understable.
