### PR TITLE
docs: simplify and reformat all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,21 @@
 <div align="center">
-    <h1>
-        <br />
-        expo hooks
-        <br />
-        <br />
-    </h1>
+    <h1>expo hooks</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
-        <a href="https://travis-ci.com/byCedric/use-expo">
-            <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/CI/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
-        <br />
-        Complementary hooks for Expo
     </sup>
     <br />
+	<br />
     <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/use-expo">use-expo</a></pre>
-    <br />
+    <pre>npm i -S use-expo</pre>
 </div>
 
 - [**Battery**](./packages/battery)
@@ -59,6 +53,5 @@
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/README.md
+++ b/README.md
@@ -6,51 +6,76 @@
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/CI/master.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add use-expo</pre>
 </div>
 
-- [**Battery**](./packages/battery)
-    - [`useBattery`](./packages/battery/docs/use-battery.md) &mdash; get the battery level, state and power mode with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
-    - [`useBatteryLevel`](./packages/battery/docs/use-battery-level.md) &mdash; get and/or listen to the battery level with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
-    - [`useBatteryLowPowerMode`](./packages/battery/docs/use-battery-low-power-mode.md) &mdash; get and/or listen to the battery low power mode with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
-    - [`useBatteryState`](./packages/battery/docs/use-battery-state.md) &mdash; get and/or listen to the battery state with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
+### [Battery](./packages/battery)
 
-- [**Brightness**](./packages/brightness)
-    - [`useBrightness`](./packages/brightness/docs/use-brightness.md) &mdash; change the screen brightness with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
-    - [`useSystemBrightness`](./packages/brightness/docs/use-system-brightness.md) &mdash; change the system brightness with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
-    - [`useSystemBrightnessMode`](./packages/brightness/docs/use-system-brightness-mode.md) &mdash; change the brightness mode with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
+- [`useBattery`](./packages/battery/docs/use-battery.md) &nbsp;&mdash;&nbsp; get the battery level, state and power mode
+- [`useBatteryLevel`](./packages/battery/docs/use-battery-level.md) &nbsp;&mdash;&nbsp; get or track the battery level or percentage remaining
+- [`useBatteryLowPowerMode`](./packages/battery/docs/use-battery-low-power-mode.md) &nbsp;&mdash;&nbsp; get or track the battery low power mode
+- [`useBatteryState`](./packages/battery/docs/use-battery-state.md) &nbsp;&mdash;&nbsp; get or track the battery (charging) state
 
-- [**Font**](./packages/font)
-    - [`useFonts`](./packages/font/docs/use-fonts.md) &mdash; load a map of fonts with [`Font`](https://docs.expo.io/versions/latest/sdk/font/)
+### [Brightness](./packages/brightness)
 
-- [**Permissions**](./packages/permissions)
-    - [`usePermissions`](./packages/permissions/docs/use-permissions.md) &mdash; get or ask permissions with [`Permissions`](https://docs.expo.io/versions/latest/sdk/permissions/)
+- [`useBrightness`](./packages/brightness/docs/use-brightness.md) &nbsp;&mdash;&nbsp; change or track the screen brightness
+- [`useSystemBrightness`](./packages/brightness/docs/use-system-brightness.md) &nbsp;&mdash;&nbsp; change or track the system screen brightness
+- [`useSystemBrightnessMode`](./packages/brightness/docs/use-system-brightness-mode.md) &nbsp;&mdash;&nbsp; change or track the system brightness mode
 
-- [**Screen Orientation**](./packages/screen-orientation)
-    - [`useScreenOrientation`](./packages/screen-orientation/docs/use-screen-orientation.md) &mdash; tracks changes in screen orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
-    - [`useScreenOrientationLock`](./packages/screen-orientation/docs/use-screen-orientation-lock.md) &mdash; locks the screen to an orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
+### [Font](./packages/font)
 
-- [**Sensors**](./packages/sensors)
-    - [`useAccelerometer`](./packages/sensors/docs/use-accelerometer.md) &mdash; tracks changes in acceleration with [`Accelerometer`](https://docs.expo.io/versions/latest/sdk/accelerometer/)
-    - [`useBarometer`](./packages/sensors/docs/use-barometer.md) &mdash; tracks changes in air pressure with [`Barometer`](https://docs.expo.io/versions/latest/sdk/barometer/)
-    - [`useDeviceMotion`](./packages/sensors/docs/use-device-motion.md) &mdash; tracks device motion and orientation with [`DeviceMotion`](https://docs.expo.io/versions/latest/sdk/devicemotion/)
-    - [`useGyroscope`](./packages/sensors/docs/use-gyroscope.md) &mdash; tracks changes in rotation with [`Gyroscope`](https://docs.expo.io/versions/latest/sdk/gyroscope/)
-    - [`useMagnetometer`](./packages/sensors/docs/use-magnetometer.md) &mdash; tracks changes in the magnetic field with [`Magnetometer`](https://docs.expo.io/versions/latest/sdk/magnetometer/)
-    - [`useMagnetometerUncalibrated`](./packages/sensors/docs/use-magnetometer.md) &mdash; tracks raw changes in the magnetic field with [`MagnetometerUncalibrated`](https://docs.expo.io/versions/latest/sdk/magnetometer/)
-    - [`usePedometer`](./packages/sensors/docs/use-pedometer.md) &mdash; tracks user step count with [`Pedometer`](https://docs.expo.io/versions/latest/sdk/pedometer/)
-    - [`usePedometerHistory`](./packages/sensors/docs/use-pedometer-history.md) &mdash; get historical step count with [`Pedometer`](https://docs.expo.io/versions/latest/sdk/pedometer/)
+- [`useFonts`](./packages/font/docs/use-fonts.md) &nbsp;&mdash;&nbsp; load a map of fonts
+
+### [Permissions](./packages/permissions)
+
+- [`usePermissions`](./packages/permissions/docs/use-permissions.md) &nbsp;&mdash;&nbsp; get or ask permissions
+
+### [Screen Orientation](./packages/screen-orientation)
+
+- [`useScreenOrientation`](./packages/screen-orientation/docs/use-screen-orientation.md) &nbsp;&mdash;&nbsp; track changes in screen orientation
+- [`useScreenOrientationLock`](./packages/screen-orientation/docs/use-screen-orientation-lock.md) &nbsp;&mdash;&nbsp; lock the screen to an orientation
+
+### [Sensors](./packages/sensors)
+
+- [`useAccelerometer`](./packages/sensors/docs/use-accelerometer.md) &nbsp;&mdash;&nbsp; track changes in acceleration
+- [`useBarometer`](./packages/sensors/docs/use-barometer.md) &nbsp;&mdash;&nbsp; track changes in air pressure
+- [`useDeviceMotion`](./packages/sensors/docs/use-device-motion.md) &nbsp;&mdash;&nbsp; track device motion and orientation
+- [`useGyroscope`](./packages/sensors/docs/use-gyroscope.md) &nbsp;&mdash;&nbsp; track changes in rotation
+- [`useMagnetometer`](./packages/sensors/docs/use-magnetometer.md) &nbsp;&mdash;&nbsp; track changes in the magnetic field
+- [`useMagnetometerUncalibrated`](./packages/sensors/docs/use-magnetometer.md) &nbsp;&mdash;&nbsp; track changes in the magnetic field using raw data
+- [`usePedometer`](./packages/sensors/docs/use-pedometer.md) &nbsp;&mdash;&nbsp; track user step count
+- [`usePedometerHistory`](./packages/sensors/docs/use-pedometer-history.md) &nbsp;&mdash;&nbsp; get historical step count between two dates
+
+
+## Usage
+
+You can import these hooks with two methods, install `use-expo` or `@use-expo/<group>` package.
+
+```js
+import { useBrightness, usePermissions } from 'use-expo';
+// or
+import { useBrightness } from '@use-expo/brightness';
+import { usePermissions } from '@use-expo/permissions';
+```
+
+> `use-expo` includes all hooks and, because of that, requires _all peer dependencies_.
+> It's recommended only to install the hooks you use to avoid unnecessary peer dependency warnings.
+
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/example/README.md
+++ b/example/README.md
@@ -1,27 +1,21 @@
 <div align="center">
-    <h1>
-        <br />
-        expo hooks
-        <br />
-        <br />
-    </h1>
+    <h1>expo hooks</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
-        <a href="https://travis-ci.com/byCedric/use-expo">
-            <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
-        <br />
-        Complementary hooks for Expo
     </sup>
     <br />
+	<br />
     <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/use-expo">use-expo</a></pre>
-    <br />
+    <pre>npm i -S use-expo</pre>
 </div>
 
 > See [`README.md`](https://github.com/bycedric/use-expo) in root.
@@ -30,6 +24,5 @@
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/example/app.json
+++ b/example/app.json
@@ -2,6 +2,7 @@
 	"expo": {
 		"name": "expo hooks",
 		"description": "complementary hooks for expo",
+		"version": "0.0.0",
 		"slug": "use-expo",
 		"privacy": "public",
 		"sdkVersion": "36.0.0",
@@ -11,7 +12,6 @@
 			"android",
 			"web"
 		],
-		"version": "0.0.0",
 		"icon": "./src/assets/images/app-icon.png",
 		"splash": {
 			"image": "./src/assets/images/app-splash.png",

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -1,35 +1,32 @@
 <div align="center">
-    <h1>
-        <br />
-        battery hooks
-        <br />
-        <br />
-    </h1>
-    <a href="https://github.com/bycedric/use-expo/releases">
-        <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
-    </a>
-    <a href="https://travis-ci.com/byCedric/use-expo">
-        <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
-    </a>
-    <a href="https://exp.host/@bycedric/use-expo">
-        <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
-    </a>
+    <h1>battery hooks</h1>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/battery">Expo battery</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
     <br />
     <br />
     <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/@use-expo/battery">@use-expo/battery</a> <a href="https://www.npmjs.com/package/expo-battery">expo-battery</a></pre>
+    <pre>npm i -S @use-expo/battery expo-battery</pre>
     <br />
 </div>
 
-- [`useBattery`](./docs/use-battery.md) &mdash; get the battery level, state and power mode with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
-- [`useBatteryLevel`](./docs/use-battery-level.md) &mdash; get and/or listen to the battery level with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
-- [`useBatteryLowPowerMode`](./docs/use-battery-low-power-mode.md) &mdash; get and/or listen to the battery low power mode with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
-- [`useBatteryState`](./docs/use-battery-state.md) &mdash; get and/or listen to the battery state with [`battery`](https://docs.expo.io/versions/latest/sdk/battery/)
+- [`useBattery`](./docs/use-battery.md) &mdash; get the battery level, state and power mode
+- [`useBatteryLevel`](./docs/use-battery-level.md) &mdash; get and/or listen to the battery level
+- [`useBatteryLowPowerMode`](./docs/use-battery-low-power-mode.md) &mdash; get and/or listen to the battery low power mode
+- [`useBatteryState`](./docs/use-battery-state.md) &mdash; get and/or listen to the battery state
 
 <div align="center">
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -1,31 +1,36 @@
 <div align="center">
     <h1>battery hooks</h1>
-    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/battery">Expo battery</a></p>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/battery/">Expo Battery</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <br />
-    <pre>npm i -S @use-expo/battery expo-battery</pre>
+    <pre>yarn add @use-expo/battery expo-battery</pre>
     <br />
 </div>
 
-- [`useBattery`](./docs/use-battery.md) &mdash; get the battery level, state and power mode
-- [`useBatteryLevel`](./docs/use-battery-level.md) &mdash; get and/or listen to the battery level
-- [`useBatteryLowPowerMode`](./docs/use-battery-low-power-mode.md) &mdash; get and/or listen to the battery low power mode
-- [`useBatteryState`](./docs/use-battery-state.md) &mdash; get and/or listen to the battery state
+- [`useBattery`](./docs/use-battery.md) &nbsp;&mdash;&nbsp; get the battery level, state and power mode
+- [`useBatteryLevel`](./docs/use-battery-level.md) &nbsp;&mdash;&nbsp; get or track the battery level or percentage remaining
+- [`useBatteryLowPowerMode`](./docs/use-battery-low-power-mode.md) &nbsp;&mdash;&nbsp; get or track the battery low power mode
+- [`useBatteryState`](./docs/use-battery-state.md) &nbsp;&mdash;&nbsp; get or track the battery (charging) state
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/packages/battery/docs/use-battery-level.md
+++ b/packages/battery/docs/use-battery-level.md
@@ -1,15 +1,24 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useBatteryLevel</code>
-        <br />
-        <br />
-    </h1>
-    get and/or listen to the battery level with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a>
+    <h1>useBatteryLevel</h1>
+    <p>Get or listen to the <a href="https://docs.expo.io/versions/latest/sdk/battery/#batterygetbatterylevelasync">battery level</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions?query=workflow%3APackages">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="#">
+            <img src="https://img.shields.io/badge/example-snack-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
     <br />
+	<br />
+    <br />
+    <pre>npm i -S @use-expo/battery expo-battery</pre>
 </div>
 
-## Examples
+## Hook
 
 ```jsx
 // full hook
@@ -19,49 +28,48 @@ const [batteryLevel, getBatteryLevel] = useBatteryLevel();
 useBatteryLevel({ get: false, listen: false });
 ```
 
-With the `useBatteryLevel` hook we can create a simple example.
+## Example
 
 ```jsx
+import { useBatteryLevel } from '@use-expo/battery';
+import { Text, View } from 'react-native';
+
 function BatteryLevelExample() {
-    const [batteryLevel] = useBatteryLevel();
+    const [level] = useBatteryLevel();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Battery level:</Text>
-            <Text>{percentage(batteryLevel)}</Text>
+            <Text>{percentage(level)}</Text>
         </View>
     );
 }
 
-function percentage(n) {
-    if (!n) {
-        return '0%';
-    }
-
-    return `${Math.floor(n * 1000) / 10}%`;
+function percentage(level = 0) {
+    return `${Math.floor(level * 1000) / 10}%`;
 }
 ```
 
 ## API
 
 ```ts
-function useBatteryLevel(options?: BatteryLevelOptions): [
-    number | undefined,
-    () => Promise<void>,
-];
+function useBatteryLevel(options?: Options): Hook;
 
-interface BatteryLevelOptions {
+interface Options {
     /** If it should fetch the battery level when mounted, defaults to `true` */
     get?: boolean;
     /** If it should listen to any change in battery level, defaults to `true` */
     listen?: boolean;
 }
+
+type Hook = [
+    number | undefined, // the battery level, when resolved ([0..1])
+    () => Promise<void>, // callback to fetch the latest info
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/battery/docs/use-battery-level.md
+++ b/packages/battery/docs/use-battery-level.md
@@ -1,24 +1,31 @@
 <div align="center">
     <h1>useBatteryLevel</h1>
-    <p>Get or listen to the <a href="https://docs.expo.io/versions/latest/sdk/battery/#batterygetbatterylevelasync">battery level</a></p>
+    <p>Get or track the battery level or percentage remaining with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
-        <a href="https://github.com/bycedric/use-expo/actions?query=workflow%3APackages">
-            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages.svg?style=flat-square" alt="builds" />
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
-        <a href="#">
-            <img src="https://img.shields.io/badge/example-snack-lightgrey.svg?style=flat-square" alt="demo" />
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S @use-expo/battery expo-battery</pre>
+    <pre>yarn add @use-expo/battery expo-battery</pre>
+    <br />
 </div>
 
-## Hook
+## Usage
 
 ```jsx
 // full hook
@@ -27,6 +34,7 @@ const [batteryLevel, getBatteryLevel] = useBatteryLevel();
 // other options
 useBatteryLevel({ get: false, listen: false });
 ```
+
 
 ## Example
 
@@ -50,10 +58,11 @@ function percentage(level = 0) {
 }
 ```
 
+
 ## API
 
 ```ts
-function useBatteryLevel(options?: Options): Hook;
+function useBatteryLevel(options?: Options): Result;
 
 interface Options {
     /** If it should fetch the battery level when mounted, defaults to `true` */
@@ -62,9 +71,11 @@ interface Options {
     listen?: boolean;
 }
 
-type Hook = [
-    number | undefined, // the battery level, when resolved ([0..1])
-    () => Promise<void>, // callback to fetch the latest info
+type Result = [
+    /** The current battery level */
+    number | undefined,
+    /** Callback to fetch the battery level */
+    () => Promise<void>,
 ];
 ```
 

--- a/packages/battery/docs/use-battery-low-power-mode.md
+++ b/packages/battery/docs/use-battery-low-power-mode.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useBatteryLowPowerMode</code>
-        <br />
-        <br />
-    </h1>
-    get and/or listen to the battery low power mode with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a>
+    <h1>useBatteryLowPowerMode</h1>
+    <p>Get or track the battery low power mode with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/battery expo-battery</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -19,14 +35,18 @@ const [isLowPowerMode, getLowPowerMode] = useBatteryLowPowerMode();
 useBatteryLowPowerMode({ get: false, listen: false });
 ```
 
-With the `useBatteryLowPowerMode` hook we can create a simple example.
+
+## Example
 
 ```jsx
+import { useBatteryLowPowerMode } from '@use-expo/battery';
+import { Text, View } from 'react-native';
+
 function BatteryLowPowerModeExample() {
     const [isLowPowerMode] = useBatteryLowPowerMode();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Battery low power mode:</Text>
             <Text>{isLowPowerMode ? 'enabled' : 'disabled'}</Text>
         </View>
@@ -34,26 +54,29 @@ function BatteryLowPowerModeExample() {
 }
 ```
 
+
 ## API
 
 ```ts
-function useBatteryLowPowerMode(options?: BatteryLowPowerModeOptions): [
-    boolean | undefined,
-    () => Promise<void>,
-];
+function useBatteryLowPowerMode(options?: Options): Result;
 
-interface BatteryLowPowerModeOptions {
+interface Options {
     /** If it should fetch the battery low power mode status when mounted, defaults to `true` */
     get?: boolean;
     /** If it should listen to any change in battery low power mode status, defaults to `true` */
     listen?: boolean;
 }
+
+type Result = [
+    /** If low power mode is enabled */
+    boolean | undefined,
+    /** Callback to manually check if low power mode is enabled */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/battery/docs/use-battery-state.md
+++ b/packages/battery/docs/use-battery-state.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useBatteryState</code>
-        <br />
-        <br />
-    </h1>
-    get and/or listen to the battery state with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a>
+    <h1>useBatteryState</h1>
+    <p>Get or track the battery (charging) state <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/battery expo-battery</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -19,50 +35,58 @@ const [batteryState, getBatteryState] = useBatteryState();
 useBatteryState({ get: false, listen: false });
 ```
 
-With the `useBatteryState` hook we can create a simple example.
+
+## Example
 
 ```jsx
-const states = {
-    [BatteryState.UNKNOWN]: 'unkown',
-    [BatteryState.UNPLUGGED]: 'unplugged',
-    [BatteryState.CHARGING]: 'charging',
-    [BatteryState.FULL]: 'full',
-}
+import { useBatteryState } from '@use-expo/battery';
+import { Text, View } from 'react-native';
+import { BatteryState } from 'expo-battery';
 
 function BatteryStateExample() {
     const [batteryState] = useBatteryState();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
-            <Text>Battery state:</Text>
+        <View>
+            <Text>Battery (charging) state:</Text>
             <Text>{states[batteryState] || ''}</Text>
         </View>
     );
 }
+
+const states = {
+    [BatteryState.UNKNOWN]: 'unkown',
+    [BatteryState.UNPLUGGED]: 'unplugged',
+    [BatteryState.CHARGING]: 'charging',
+    [BatteryState.FULL]: 'full',
+};
 ```
+
 
 ## API
 
 ```ts
 import { BatteryState } from 'expo-battery';
 
-function useBatteryState(options?: BatteryStateOptions): [
-    BatteryState | undefined,
-    () => Promise<void>,
-];
+function useBatteryState(options?: Options): Result;
 
-interface BatteryStateOptions {
+interface Options {
     /** If it should fetch the battery state when mounted, defaults to `true` */
     get?: boolean;
     /** If it should listen to any change in battery state, defaults to `true` */
     listen?: boolean;
 }
+
+type Result = [
+    /** The current battery (charging) state */
+    BatteryState | undefined,
+    /** Callback to manually get the battery state */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/battery/docs/use-battery.md
+++ b/packages/battery/docs/use-battery.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useBattery</code>
-        <br />
-        <br />
-    </h1>
-    get the battery level, state and power mode with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a>
+    <h1>useBattery</h1>
+    <p>Get the battery level, state and power mode with <a href="https://docs.expo.io/versions/latest/sdk/battery/"><code>Battery</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/battery expo-battery</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -19,55 +35,58 @@ const [battery, getBattery] = useBattery();
 useBattery({ get: false });
 ```
 
-With the `useBattery` hook we can create a simple example.
+
+## Example
 
 ```jsx
+import { useBattery } from '@use-expo/battery';
+import { Text, View } from 'react-native';
+
 function BatteryExample() {
     const [battery] = useBattery();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Battery:</Text>
             {!!battery && (
                 <View>
                     <Text>level: {percentage(battery.batteryLevel)}</Text>
                     <Text>state: {battery.batteryState}</Text>
-                    <Text>low power: {battery.lowPowerMode ? 'true' : 'false'}</Text>
+                    <Text>low power: {battery.lowPowerMode ? 'enabled' : 'disabled'}</Text>
                 </View>
             )}
         </View>
     );
 }
 
-function percentage(n) {
-    if (!n) {
-        return '0%';
-    }
-
-    return `${Math.floor(n * 1000) / 10}%`;
+function percentage(level = 0) {
+    return `${Math.floor(level * 1000) / 10}%`;
 }
 ```
+
 
 ## API
 
 ```ts
 import { PowerState } from 'expo-battery';
 
-function useBattery(options?: BatteryOptions): [
-    PowerState | undefined,
-    () => Promise<void>,
-];
+function useBattery(options?: Options): Result;
 
-interface BatteryOptions {
+interface Options {
     /** If it should fetch the battery power state when mounted, defaults to `true` */
     get?: boolean;
 }
+
+type Result = [
+    /** The current power state */
+    PowerState | undefined,
+    /** Callback to manually get the power state data */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/brightness/README.md
+++ b/packages/brightness/README.md
@@ -1,52 +1,35 @@
 <div align="center">
-    <h1>
-        <br />
-        brightness hooks
-        <br />
-        <br />
-    </h1>
-    <a href="https://github.com/bycedric/use-expo/releases">
-        <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
-    </a>
-    <a href="https://travis-ci.com/byCedric/use-expo">
-        <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
-    </a>
-    <a href="https://exp.host/@bycedric/use-expo">
-        <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
-    </a>
-    <br />
-    <br />
-    <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/@use-expo/brightness">@use-expo/brightness</a> <a href="https://www.npmjs.com/package/expo-brightness">expo-brightness</a></pre>
-    <br />
-</div>
-
-<div align="center">
-    <h1>use-expo</h1>
-    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <h1>brightness hooks</h1>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/brightness/">Expo Brightness</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add @use-expo/brightness expo-brightness</pre>
+    <br />
 </div>
 
-- [`useBrightness`](./docs/use-brightness.md) &mdash; change the screen brightness with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
-- [`useSystemBrightness`](./docs/use-system-brightness.md) &mdash; change the system brightness with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
-- [`useSystemBrightnessMode`](./docs/use-system-brightness-mode.md) &mdash; change the brightness mode with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
+- [`useBrightness`](./docs/use-brightness.md) &nbsp;&mdash;&nbsp; change or track the screen brightness
+- [`useSystemBrightness`](./docs/use-system-brightness.md) &nbsp;&mdash;&nbsp; change or track the system screen brightness
+- [`useSystemBrightnessMode`](./docs/use-system-brightness-mode.md) &nbsp;&mdash;&nbsp; change or track the system brightness mode
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/packages/brightness/README.md
+++ b/packages/brightness/README.md
@@ -21,6 +21,26 @@
     <br />
 </div>
 
+<div align="center">
+    <h1>use-expo</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+	<br />
+    <br />
+    <pre>npm i -S use-expo</pre>
+</div>
+
 - [`useBrightness`](./docs/use-brightness.md) &mdash; change the screen brightness with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
 - [`useSystemBrightness`](./docs/use-system-brightness.md) &mdash; change the system brightness with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
 - [`useSystemBrightnessMode`](./docs/use-system-brightness-mode.md) &mdash; change the brightness mode with [`Brightness`](https://docs.expo.io/versions/latest/sdk/brightness/)
@@ -29,6 +49,5 @@
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/brightness/docs/use-brightness.md
+++ b/packages/brightness/docs/use-brightness.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useBrightness</code>
-        <br />
-        <br />
-    </h1>
-    change the screen brightness with <a href="https://docs.expo.io/versions/latest/sdk/brightness/"><code>Brightness</code></a>
+    <h1>useBrightness</h1>
+    <p>Change or track the screen brightness with <a href="https://docs.expo.io/versions/latest/sdk/brightness/"><code>Brightness</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/brightness expo-brightness</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -19,14 +35,18 @@ const [brightness, setBrightness, getBrightness] = useBrightness();
 useBrightness({ get: false });
 ```
 
-With the `useBrightness` hook we can create a simple example.
+
+## Example
 
 ```jsx
+import { useBrightness } from '@use-expo/brightness';
+import { Slider, Text, View } from 'react-native';
+
 function BrightnessExample() {
     const [brightness, setBrightness] = useBrightness();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Brightness:</Text>
             <Text>{percentage(brightness)}</Text>
             <Slider
@@ -40,34 +60,34 @@ function BrightnessExample() {
     );
 }
 
-function percentage(n) {
-    if (!n) {
-        return '0%';
-    }
-
-    return `${Math.floor(n * 1000) / 10}%`;
+function percentage(level = 0) {
+    return `${Math.floor(level * 1000) / 10}%`;
 }
 ```
+
 
 ## API
 
 ```ts
-function useBrightness(options?: BrightnessOptions): [
-    number | undefined,
-    (brightness: number) => Promise<void>,
-    () => Promise<void>,
-];
+function useBrightness(options?: Options): Result;
 
-interface BrightnessOptions {
+interface Options {
     /** If it should fetch the brightness when mounted, defaults to `true` */
     get?: boolean;
 }
+
+type Result = [
+    /** The current brightness */
+    number | undefined,
+    /** Callback to change the brightness */
+    (brightness: number) => Promise<void>,
+    /** Callback to manually get the brightness */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/brightness/docs/use-system-brightness-mode.md
+++ b/packages/brightness/docs/use-system-brightness-mode.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useSystemBrightnessMode</code>
-        <br />
-        <br />
-    </h1>
-    change the system brightness mode with <a href="https://docs.expo.io/versions/latest/sdk/brightness/"><code>Brightness</code></a>
+    <h1>useSystemBrightnessMode</h1>
+    <p>Change or track the system brightness mode with <a href="https://docs.expo.io/versions/latest/sdk/brightness/"><code>Brightness</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/brightness expo-brightness</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -19,30 +35,33 @@ const [mode, setMode, getMode] = useSystemBrightnessMode();
 useSystemBrightnessMode({ get: false });
 ```
 
-With the `useSystemBrightnessMode` and `usePermissions` hooks we can create a simple example.
+
+## Example
 
 ```jsx
-const Mode = {
-    unknown: 0,
-    automatic: 1,
-    manual: 2,
-};
+import { useSystemBrightnessMode } from '@use-expo/brightness';
+import { usePermissions } from '@use-expo/permissions';
+import * as Permissions from 'expo-permissions';
+import { Button, Linking, Text, View } from 'react-native';
 
 function SystemBrightnessMode() {
     const [permission, askPermission] = usePermissions(Permissions.SYSTEM_BRIGHTNESS);
     const [mode, setMode] = useSystemBrightnessMode();
 
-    if (!permission || permission.status !== 'granted') {
+    if (permission?.status !== 'granted') {
         return (
-            <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
-                <Text>We require permissions to change the system brightness mode</Text>
-                <Button onPress={askPermission} title='Ask for permission' />
+            <View>
+                <Text>We need permissions to change the system brightness mode</Text>
+                {permission?.canAskAgain
+                    ? <Button onPress={askPermission} title='Give permission' />
+                    : <Button onPress={Linking.openSettings} title='Open app settings' />
+                }
             </View>
         );
     }
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Change the system brightness mode to:</Text>
             <Button
                 title='unknown'
@@ -63,6 +82,12 @@ function SystemBrightnessMode() {
     );
 }
 
+const Mode = {
+    unknown: 0,
+    automatic: 1,
+    manual: 2,
+};
+
 function getColor(mode, target) {
     if (mode === target) {
         return '#841584';
@@ -70,27 +95,31 @@ function getColor(mode, target) {
 }
 ```
 
+
 ## API
 
 ```ts
 import { BrightnessMode } from 'expo-brightness';
 
-function useSystemBrightnessMode(options?: SystemBrightnessModeOptions): [
-    BrightnessMode | undefined,
-    (mode: BrightnessMode) => Promise<void>,
-    () => Promise<void>,
-];
+function useSystemBrightnessMode(options?: Options): Result;
 
-interface SystemBrightnessModeOptions {
+interface Options {
     /** If it should fetch the brightness mode when mounted, defaults to `true` */
     get?: boolean;
 }
+
+type Result = [
+    /** The current system brightness mode */
+    BrightnessMode | undefined,
+    /** Callback to change the system brightness mode */
+    (mode: BrightnessMode) => Promise<void>,
+    /** Callback to manually get the system brightness mode */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/brightness/docs/use-system-brightness.md
+++ b/packages/brightness/docs/use-system-brightness.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useSystemBrightness</code>
-        <br />
-        <br />
-    </h1>
-    change the system brightness with <a href="https://docs.expo.io/versions/latest/sdk/brightness/"><code>Brightness</code></a>
+    <h1>useSystemBrightness</h1>
+    <p>Change or track the system screen brightness with <a href="https://docs.expo.io/versions/latest/sdk/brightness/"><code>Brightness</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/brightness expo-brightness</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -19,27 +35,33 @@ const [brightness, setBrightness, getBrightness] = useSystemBrightness();
 useSystemBrightness({ get: false });
 ```
 
-With the `useSystemBrightness` and `usePermissions` hooks we can create a simple example.
+
+## Example
 
 ```jsx
+import { useSystemBrightness } from '@use-expo/brightness';
+import { usePermissions } from '@use-expo/permissions';
+import * as Permissions from 'expo-permissions';
+import { Button, Linking, Slider, Text, View } from 'react-native';
+
 function SystemBrightnessExample() {
     const [permission, askPermission] = usePermissions(Permissions.SYSTEM_BRIGHTNESS);
     const [brightness, setBrightness] = useSystemBrightness();
 
-    if (!permission || permission.status !== 'granted') {
+    if (permission?.status !== 'granted') {
         return (
-            <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+            <View>
                 <Text>We require permissions to set the system brightness</Text>
-                <Button
-                    title='Give permission'
-                    onPress={askPermission}
-                />
+                {permission?.canAskAgain
+                    ? <Button onPress={askPermission} title='Give permission' />
+                    : <Button onPress={Linking.openSettings} title='Open app settings' />
+                }
             </View>
         );
     }
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>System brightness:</Text>
             <Text>{percentage(brightness)}</Text>
             <Slider
@@ -53,34 +75,34 @@ function SystemBrightnessExample() {
     );
 }
 
-function percentage(n) {
-    if (!n) {
-        return '0%';
-    }
-
-    return `${Math.floor(n * 1000) / 10}%`;
+function percentage(level = 0) {
+    return `${Math.floor(level * 1000) / 10}%`;
 }
 ```
+
 
 ## API
 
 ```ts
-function useSystemBrightness(options?: SystemBrightnessOptions): [
-    number | undefined,
-    (brightness: number) => Promise<void>,
-    () => Promise<void>,
-];
+function useSystemBrightness(options?: Options): Result;
 
-interface SystemBrightnessOptions {
+interface Options {
     /** If it should fetch the brightness when mounted, defaults to `true` */
     get?: boolean;
 }
+
+type Result = [
+    /** The current system brightness */
+    number | undefined,
+    /** Callback to change the system brightness */
+    (brightness: number) => Promise<void>,
+    /** Callback to manually get the system brightness */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/font/README.md
+++ b/packages/font/README.md
@@ -1,50 +1,33 @@
 <div align="center">
-    <h1>
-        <br />
-        font hooks
-        <br />
-        <br />
-    </h1>
-    <a href="https://github.com/bycedric/use-expo/releases">
-        <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
-    </a>
-    <a href="https://travis-ci.com/byCedric/use-expo">
-        <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
-    </a>
-    <a href="https://exp.host/@bycedric/use-expo">
-        <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
-    </a>
-    <br />
-    <br />
-    <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/@use-expo/permissions">@use-expo/font</a> <a href="https://www.npmjs.com/package/expo-asset">expo-asset</a> <a href="https://www.npmjs.com/package/expo-font">expo-font</a></pre>
-    <br />
-</div>
-
-<div align="center">
-    <h1>use-expo</h1>
-    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <h1>font hooks</h1>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/font/">Expo Font</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add @use-expo/font expo-font</pre>
+    <br />
 </div>
 
-- [`useFonts`](./docs/use-fonts.md) &mdash; load a map of fonts with [`Font`](https://docs.expo.io/versions/latest/sdk/font/)
+- [`useFonts`](./docs/use-fonts.md) &nbsp;&mdash;&nbsp; load a map of fonts
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/packages/font/README.md
+++ b/packages/font/README.md
@@ -21,12 +21,31 @@
     <br />
 </div>
 
+<div align="center">
+    <h1>use-expo</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+	<br />
+    <br />
+    <pre>npm i -S use-expo</pre>
+</div>
+
 - [`useFonts`](./docs/use-fonts.md) &mdash; load a map of fonts with [`Font`](https://docs.expo.io/versions/latest/sdk/font/)
 
 <div align="center">
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/font/docs/use-fonts.md
+++ b/packages/font/docs/use-fonts.md
@@ -1,24 +1,45 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useFonts</code>
-        <br />
-        <br />
-    </h1>
-    load a map of fonts with <a href="https://docs.expo.io/versions/latest/sdk/font/"><code>Font</code></a>
+    <h1>useFonts</h1>
+    <p>Load a map of fonts with <a href="https://docs.expo.io/versions/latest/sdk/font/"><code>Font</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/font expo-font</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
 const [isLoaded] = useFonts({ ... });
 ```
 
-With the `useFonts` hook we can simplify the [Font example from the Expo docs](https://docs.expo.io/versions/latest/font/#example).
+
+## Example
 
 ```jsx
+import { useFonts } from '@use-expo/font';
+import { AppLoading } from 'expo';
+import { Text, View } from 'react-native';
+
 const customFonts = {
     'OpenSans-Regular': require('./assets/fonts/open-sans-regular.ttf'),
 };
@@ -38,22 +59,27 @@ function FontExample() {
 }
 ```
 
+
 ## API
 
 ```ts
-import { Asset } from 'expo-asset';
+import { FontSource } from 'expo-font';
 
-function useFonts(map: FontMap): [boolean];
+function useFonts(map: FontMap): Result;
 
 interface FontMap {
-    [name: string]: string | number | Asset;
+    /** All fonts, by name, to load */
+    [name: string]: FontSource;
 }
+
+type Result = [
+    /** If the fonts are loaded or not */
+    boolean,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -21,12 +21,31 @@
     <br />
 </div>
 
+<div align="center">
+    <h1>use-expo</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+	<br />
+    <br />
+    <pre>npm i -S use-expo</pre>
+</div>
+
 - [`usePermissions`](./docs/use-permissions.md) &mdash; get or ask permissions with [`Permissions`](https://docs.expo.io/versions/latest/sdk/permissions/)
 
 <div align="center">
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -1,50 +1,33 @@
 <div align="center">
-    <h1>
-        <br />
-        permission hooks
-        <br />
-        <br />
-    </h1>
-    <a href="https://github.com/bycedric/use-expo/releases">
-        <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
-    </a>
-    <a href="https://travis-ci.com/byCedric/use-expo">
-        <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
-    </a>
-    <a href="https://exp.host/@bycedric/use-expo">
-        <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
-    </a>
-    <br />
-    <br />
-    <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/@use-expo/permissions">@use-expo/permissions</a> <a href="https://www.npmjs.com/package/expo-permissions">expo-permissions</a></pre>
-    <br />
-</div>
-
-<div align="center">
-    <h1>use-expo</h1>
-    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <h1>permission hooks</h1>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/permissions/">Expo Permissions</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add @use-expo/permissions expo-permissions</pre>
+    <br />
 </div>
 
-- [`usePermissions`](./docs/use-permissions.md) &mdash; get or ask permissions with [`Permissions`](https://docs.expo.io/versions/latest/sdk/permissions/)
+- [`usePermissions`](./docs/use-permissions.md) &nbsp;&mdash;&nbsp; get or ask permissions
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/packages/permissions/docs/use-permissions.md
+++ b/packages/permissions/docs/use-permissions.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>usePermissions</code>
-        <br />
-        <br />
-    </h1>
-    get or ask permissions with <a href="https://docs.expo.io/versions/latest/sdk/permissions/"><code>Permissions</code></a>
+    <h1>usePermissions</h1>
+    <p>Get or ask permissions with <a href="https://docs.expo.io/versions/latest/sdk/permissions/"><code>Permissions</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/permissions expo-permissions</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -22,70 +38,88 @@ usePermissions(Permissions.LOCATION, { ask: true });
 usePermissions(Permissions.NOTIFICATIONS, { get: false });
 ```
 
-With the `usePermissions` hook we can simplify the [Camera example for the Expo docs](https://docs.expo.io/versions/latest/sdk/camera/).
+
+## Example
 
 ```jsx
+import { usePermissions } from '@use-expo/permissions';
+import { Camera } from 'expo-camera';
+import * as Permissions from 'expo-permissions';
+import { useState } from 'react';
+import { Button, Linking, Text, TouchableOpacity, View } from 'react-native';
+
 function CameraExample() {
     const [camera, setCamera] = useState(Camera.Constants.Type.back);
-    const [permission] = usePermissions(Permissions.CAMERA, { ask: true });
+    const [permission, askPermission] = usePermissions(Permissions.CAMERA, { ask: true });
 
     if (!permission) {
-        return <View />;
-    } else if (permission.status !== 'granted') {
-        return <Text>No access to camera</Text>;
-    } else {
-        return (
-            <View style={{ flex: 1 }}>
-                <Camera style={{ flex: 1 }} type={camera}>
-                    <View style={{ flex: 1, backgroundColor: 'transparent', flexDirection: 'row' }}>
-                        <TouchableOpacity
-                            style={{ flex: 0.1, alignSelf: 'flex-end', alignItems: 'center' }}
-                            onPress={() => {
-                                setCamera(
-                                    camera === Camera.Constants.Type.back
-                                        ? Camera.Constants.Type.front
-                                        : Camera.Constants.Type.back
-                                    );
-                            }}
-                        >
-                            <Text style={{ fontSize: 18, marginBottom: 10, color: 'white' }}>
-                                Flip
-                            </Text>
-                        </TouchableOpacity>
-                    </View>
-                </Camera>
+        return null;
+    }
+
+    if (permission.status !== 'granted') {
+         return (
+            <View>
+                <Text>We need permissions to use the camera</Text>
+                {permission?.canAskAgain
+                    ? <Button onPress={askPermission} title='Give permission' />
+                    : <Button onPress={Linking.openSettings} title='Open app settings' />
+                }
             </View>
         );
     }
+
+    return (
+        <View style={{ flex: 1 }}>
+            <Camera style={{ flex: 1 }} type={camera}>
+                <View style={{ flex: 1, backgroundColor: 'transparent', flexDirection: 'row' }}>
+                    <TouchableOpacity
+                        style={{ flex: 0.1, alignSelf: 'flex-end', alignItems: 'center' }}
+                        onPress={() => {
+                            setCamera(
+                                camera === Camera.Constants.Type.back
+                                    ? Camera.Constants.Type.front
+                                    : Camera.Constants.Type.back
+                            );
+                        }}
+                    >
+                        <Text style={{ fontSize: 18, marginBottom: 10, color: 'white' }}>
+                            Flip
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+            </Camera>
+        </View>
+    );
 }
 ```
+
 
 ## API
 
 ```ts
 import { PermissionType, PermissionResponse } from 'expo-permissions';
 
-function usePermissions(
-    type: PermissionType | PermissionType[],
-    options?: PermissionsOptions,
-): [
-    PermissionResponse | undefined,
-    (): Promise<void>,
-    (): Promise<void>,
-];
+function usePermissions(type: PermissionType | PermissionType[], options?: Options): Result;
 
-interface PermissionsOptions {
+interface Options {
     /** If it should ask the permissions when mounted, defaults to `false` */
     ask?: boolean;
     /** If it should fetch information about the permissions when mounted, defaults to `true` */
     get?: boolean;
 }
+
+type Result = [
+    /** The received permission response */
+    PermissionResponse | undefined,
+    /** Callback to ask the user for the permissions */
+    () => Promise<void>,
+    /** Callback to manually check if the permissions are granted */
+    () => Promise<void>,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/screen-orientation/README.md
+++ b/packages/screen-orientation/README.md
@@ -1,51 +1,34 @@
 <div align="center">
-    <h1>
-        <br />
-        screen orientation hooks
-        <br />
-        <br />
-    </h1>
-    <a href="https://github.com/bycedric/use-expo/releases">
-        <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
-    </a>
-    <a href="https://travis-ci.com/byCedric/use-expo">
-        <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
-    </a>
-    <a href="https://exp.host/@bycedric/use-expo">
-        <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
-    </a>
-    <br />
-    <br />
-    <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/@use-expo/screen-orientation">@use-expo/screen-orientation</a></pre>
-    <br />
-</div>
-
-<div align="center">
-    <h1>use-expo</h1>
-    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <h1>screen orientation hooks</h1>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/screen-orientation/">Expo Screen Orientation</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add @use-expo/screen-orientation</pre>
+    <br />
 </div>
 
-- [`useScreenOrientation`](./docs/use-screen-orientation.md) &mdash; tracks changes in screen orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
-- [`useScreenOrientationLock`](./docs/use-screen-orientation-lock.md) &mdash; locks the screen to an orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
+- [`useScreenOrientation`](./docs/use-screen-orientation.md) &nbsp;&mdash;&nbsp; track changes in screen orientation
+- [`useScreenOrientationLock`](./docs/use-screen-orientation-lock.md) &nbsp;&mdash;&nbsp; lock the screen to an orientation
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/packages/screen-orientation/README.md
+++ b/packages/screen-orientation/README.md
@@ -21,6 +21,26 @@
     <br />
 </div>
 
+<div align="center">
+    <h1>use-expo</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+	<br />
+    <br />
+    <pre>npm i -S use-expo</pre>
+</div>
+
 - [`useScreenOrientation`](./docs/use-screen-orientation.md) &mdash; tracks changes in screen orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
 - [`useScreenOrientationLock`](./docs/use-screen-orientation-lock.md) &mdash; locks the screen to an orientation with [`ScreenOrientation`](https://docs.expo.io/versions/latest/sdk/screen-orientation/)
 
@@ -28,6 +48,5 @@
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/screen-orientation/docs/use-screen-orientation-lock.md
+++ b/packages/screen-orientation/docs/use-screen-orientation-lock.md
@@ -1,45 +1,66 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useScreenOrientationLock</code>
-        <br />
-        <br />
-    </h1>
-    locks the screen to an orientation with <a href="https://docs.expo.io/versions/latest/sdk/screen-orientation/"><code>ScreenOrientation</code></a>
+    <h1>useScreenOrientationLock</h1>
+    <p>Lock the screen to an orientation with <a href="https://docs.expo.io/versions/latest/sdk/screen-orientation/"><code>ScreenOrientation</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/screen-orientation</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
 useScreenOrientationLock(OrientationLock.LANDSCAPE_LEFT);
 ```
 
-With the `useScreenOrientationLock` hook we can create a simple example.
+
+## Example
 
 ```jsx
+import { useScreenOrientationLock } from '@use-expo/screen-orientation';
+import { Text, View } from 'react-native';
+
 function ScreenOrientationLockExample() {
     useScreenOrientationLock(OrientationLock.PORTRAIT_UP);
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>This screen is now locked to portrait mode</Text>
         </View>
     );
 }
 ```
 
+
 ## API
 
 ```ts
+import { ScreenOrientation } from 'expo';
+
 function useScreenOrientationLock(orientation: ScreenOrientation.OrientationLock): void;
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/screen-orientation/docs/use-screen-orientation.md
+++ b/packages/screen-orientation/docs/use-screen-orientation.md
@@ -1,32 +1,52 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useScreenOrientation</code>
-        <br />
-        <br />
-    </h1>
-    tracks changes in screen orientation with <a href="https://docs.expo.io/versions/latest/sdk/screen-orientation/"><code>ScreenOrientation</code></a>
+    <h1>useScreenOrientation</h1>
+    <p>Track changes in screen orientation with <a href="https://docs.expo.io/versions/latest/sdk/screen-orientation/"><code>ScreenOrientation</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/screen-orientation</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
 const [orientation, sizeClass] = useScreenOrientation();
 
 // other options
-useScreenOrientation({ get: false });
+useScreenOrientation({ get: false, listen: false });
 ```
 
-With the `useScreenOrientation` hook we can create a simple example.
+
+## Example
 
 ```jsx
+import { useScreenOrientation } from '@use-expo/screen-orientation';
+import { Text, View } from 'react-native';
+
 function ScreenOrientationExample() {
     const [orientation, sizeClass] = useScreenOrientation();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Screen orientation:</Text>
             <Text>{orientation}</Text>
             <Text>Screen size class: (only available on iOS)</Text>
@@ -36,18 +56,27 @@ function ScreenOrientationExample() {
 }
 ```
 
+
 ## API
 
 ```ts
-function useScreenOrientation(options?: ScreenOrientationOptions): [
-    ScreenOrientation.Orientation | undefined,
-    ScreenOrientationSizeClass | undefined,
-];
+function useScreenOrientation(options?: Options): Result;
 
-interface ScreenOrientationOptions {
+interface Options {
     /** If it should fetch the screen orientation when mounted, defaults to `true` */
     get?: boolean;
+    /** If it should listen to screen orientation changes, defaults to `true` */
+	listen?: boolean;
 }
+
+type Result = [
+    /** The current orientation of the screen */
+    ScreenOrientation.Orientation | undefined,
+    /** The (iOS) screen size class */
+    ScreenOrientationSizeClass | undefined,
+    /** Callback to manually get the screen orientation */
+    () => Promise<void>;
+];
 
 /** Both the horizontal and vertical size class, only available on iOS */
 interface ScreenOrientationSizeClass {
@@ -58,8 +87,6 @@ interface ScreenOrientationSizeClass {
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -21,6 +21,26 @@
     <br />
 </div>
 
+<div align="center">
+    <h1>use-expo</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+	<br />
+    <br />
+    <pre>npm i -S use-expo</pre>
+</div>
+
 - [`useAccelerometer`](./docs/use-accelerometer.md) &mdash; tracks changes in acceleration with [`Accelerometer`](https://docs.expo.io/versions/latest/sdk/accelerometer/)
 - [`useBarometer`](./docs/use-barometer.md) &mdash; tracks changes in air pressure with [`Barometer`](https://docs.expo.io/versions/latest/sdk/barometer/)
 - [`useDeviceMotion`](./docs/use-device-motion.md) &mdash; tracks device motion and orientation with [`DeviceMotion`](https://docs.expo.io/versions/latest/sdk/devicemotion/)
@@ -34,6 +54,5 @@
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -1,57 +1,40 @@
 <div align="center">
-    <h1>
-        <br />
-        sensor hooks
-        <br />
-        <br />
-    </h1>
-    <a href="https://github.com/bycedric/use-expo/releases">
-        <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
-    </a>
-    <a href="https://travis-ci.com/byCedric/use-expo">
-        <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
-    </a>
-    <a href="https://exp.host/@bycedric/use-expo">
-        <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
-    </a>
-    <br />
-    <br />
-    <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/@use-expo/sensors">@use-expo/sensors</a> <a href="https://www.npmjs.com/package/expo-sensors">expo-sensors</a></pre>
-    <br />
-</div>
-
-<div align="center">
-    <h1>use-expo</h1>
-    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <h1>sensor hooks</h1>
+    <p>Complementary hooks for <a href="https://docs.expo.io/versions/latest/sdk/sensors/">Expo Sensors</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
+    <br />
 </div>
 
-- [`useAccelerometer`](./docs/use-accelerometer.md) &mdash; tracks changes in acceleration with [`Accelerometer`](https://docs.expo.io/versions/latest/sdk/accelerometer/)
-- [`useBarometer`](./docs/use-barometer.md) &mdash; tracks changes in air pressure with [`Barometer`](https://docs.expo.io/versions/latest/sdk/barometer/)
-- [`useDeviceMotion`](./docs/use-device-motion.md) &mdash; tracks device motion and orientation with [`DeviceMotion`](https://docs.expo.io/versions/latest/sdk/devicemotion/)
-- [`useGyroscope`](./docs/use-gyroscope.md) &mdash; tracks changes in rotation with [`Gyroscope`](https://docs.expo.io/versions/latest/sdk/gyroscope/)
-- [`useMagnetometer`](./docs/use-magnetometer.md) &mdash; tracks changes in the magnetic field with [`Magnetometer`](https://docs.expo.io/versions/latest/sdk/magnetometer/)
-- [`useMagnetometerUncalibrated`](./docs/use-magnetometer.md) &mdash; tracks raw changes in the magnetic field with [`MagnetometerUncalibrated`](https://docs.expo.io/versions/latest/sdk/magnetometer/)
-- [`usePedometer`](./docs/use-pedometer.md) &mdash; tracks user step count with [`Pedometer`](https://docs.expo.io/versions/latest/sdk/pedometer/)
-- [`usePedometerHistory`](./docs/use-pedometer-history.md) &mdash; get historical step count with [`Pedometer`](https://docs.expo.io/versions/latest/sdk/pedometer/)
+- [`useAccelerometer`](./docs/use-accelerometer.md) &nbsp;&mdash;&nbsp; track changes in acceleration
+- [`useBarometer`](./docs/use-barometer.md) &nbsp;&mdash;&nbsp; track changes in air pressure
+- [`useDeviceMotion`](./docs/use-device-motion.md) &nbsp;&mdash;&nbsp; track device motion and orientation
+- [`useGyroscope`](./docs/use-gyroscope.md) &nbsp;&mdash;&nbsp; track changes in rotation
+- [`useMagnetometer`](./docs/use-magnetometer.md) &nbsp;&mdash;&nbsp; track changes in the magnetic field
+- [`useMagnetometerUncalibrated`](./docs/use-magnetometer.md) &nbsp;&mdash;&nbsp; track changes in the magnetic field using raw data
+- [`usePedometer`](./docs/use-pedometer.md) &nbsp;&mdash;&nbsp; track user step count
+- [`usePedometerHistory`](./docs/use-pedometer-history.md) &nbsp;&mdash;&nbsp; get historical step count between two dates
 
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />

--- a/packages/sensors/docs/use-accelerometer.md
+++ b/packages/sensors/docs/use-accelerometer.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useAccelerometer</code>
-        <br />
-        <br />
-    </h1>
-    tracks changes in acceleration with <a href="https://docs.expo.io/versions/latest/sdk/accelerometer/"><code>Accelerometer</code></a>
+    <h1>useAccelerometer</h1>
+    <p>Track changes in acceleration with <a href="https://docs.expo.io/versions/latest/sdk/accelerometer/"><code>Accelerometer</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -17,20 +33,24 @@ const [data, isAvailable] = useAccelerometer();
 
 // other options
 useAccelerometer({ interval: 1000 });
-useAccelerometer({ initial: { x: 1, y: 1, z: 1 } });
 useAccelerometer({ availability: false });
+useAccelerometer({ initial: { x: 1, y: 1, z: 1 } });
 ```
 
-With the `useAccelerometer` hook we can simplify the [Accelerometer example for the Expo docs](https://docs.expo.io/versions/latest/sdk/accelerometer/#example-basic-subscription).
+
+## Example
 
 ```jsx
+import { useAccelerometer } from '@use-expo/sensors';
+import { Text, View } from 'react-native';
+
 function AccelerometerSensor() {
-    const [data, isAvailable] = useAccelerometer({ interval: 100 });
+    const [data, available] = useAccelerometer({ interval: 100 });
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Accelerometer:</Text>
-            {(isAvailable && data)
+            {(available && data)
                 ? <Text>x: {round(data.x)} y: {round(data.y)} z: {round(data.z)}</Text>
                 : <Text>unavailable</Text>
             }
@@ -38,30 +58,25 @@ function AccelerometerSensor() {
     );
 }
 
-function round(n) {
-    if (!n) {
-        return 0;
-    }
-
-    return Math.floor(n * 100) / 100;
+function round(value = 0) {
+    return Math.floor(value * 100) / 100;
 }
 ```
+
 
 ## API
 
 ```ts
 import { ThreeAxisMeasurement } from 'expo-sensors';
 
-function useAccelerometer(options?: AccelerometerOptions): [
-    ThreeAxisMeasurement | undefined,
-    boolean | undefined,
-];
+function useAccelerometer(options?: Options): Result;
 
-interface AccelerometerOptions {
+interface Options {
     /** The initial data to use before the first update. */
     initial?: ThreeAxisMeasurement;
     /** If it should check the availability of the sensor, defaults to `true`. */
     availability?: boolean;
+
     /**
      * The interval, in ms, to update the accelerometer data.
      * Note, this is set globally through `Accelerometer.setUpdateInterval`.
@@ -69,12 +84,15 @@ interface AccelerometerOptions {
      */
     interval?: number;
 }
+
+type Result = [
+    ThreeAxisMeasurement | undefined,
+    boolean | undefined,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/docs/use-barometer.md
+++ b/packages/sensors/docs/use-barometer.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useBarometer</code>
-        <br />
-        <br />
-    </h1>
-    tracks changes in air pressure with <a href="https://docs.expo.io/versions/latest/sdk/barometer/"><code>Barometer</code></a>
+    <h1>useBarometer</h1>
+    <p>Track changes in air pressure with <a href="https://docs.expo.io/versions/latest/sdk/barometer/"><code>Barometer</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -17,20 +33,24 @@ const [data, isAvailable] = useBarometer();
 
 // other options
 useBarometer({ interval: 1000 });
-useBarometer({ initial: { pressure: 0 } });
 useBarometer({ availability: false });
+useBarometer({ initial: { pressure: 0 } });
 ```
 
-With the `useBarometer` hook we can simplify the [Barometer example for the Expo docs](https://docs.expo.io/versions/latest/sdk/barometer/#example-basic-subscription).
+
+## Example
 
 ```jsx
+import { useBarometer } from '@use-expo/sensors';
+import { Text, View } from 'react-native';
+
 function BarometerSensor() {
-    const [data, isAvailable] = useBarometer({ initial: { pressure: 0 } });
+    const [data, available] = useBarometer({ initial: { pressure: 0 } });
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Barometer:</Text>
-            {(isAvailable && data)
+            {available
                 ? <Text>{data.pressure * 100} Pa</Text>
                 : <Text>unavailable</Text>
             }
@@ -39,21 +59,20 @@ function BarometerSensor() {
 }
 ```
 
+
 ## API
 
 ```ts
 import { BarometerMeasurement } from 'expo-sensors';
 
-function useBarometer(options?: BarometerOptions): [
-    BarometerMeasurement | undefined,
-    boolean | undefined,
-];
+function useBarometer(options?: Options): Result;
 
-interface BarometerOptions {
+interface Options {
     /** The initial data to use before the first update. */
     initial?: BarometerMeasurement;
     /** If it should check the availability of the sensor, defaults to `true`. */
     availability?: boolean;
+
     /**
      * The interval, in ms, to update the barometer data.
      * Note, this is set globally through `Barometer.setUpdateInterval`.
@@ -61,12 +80,15 @@ interface BarometerOptions {
      */
     interval?: number;
 }
+
+type Result = [
+    BarometerMeasurement | undefined,
+    boolean | undefined,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/docs/use-device-motion.md
+++ b/packages/sensors/docs/use-device-motion.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useDeviceMotion</code>
-        <br />
-        <br />
-    </h1>
-    tracks device motion and orientation with <a href="https://docs.expo.io/versions/latest/sdk/devicemotion/"><code>DeviceMotion</code></a>
+    <h1>useDeviceMotion</h1>
+    <p>Track device motion and orientation with <a href="https://docs.expo.io/versions/latest/sdk/devicemotion/"><code>DeviceMotion</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -17,20 +33,24 @@ const [data, isAvailable] = useDeviceMotion();
 
 // other options
 useDeviceMotion({ interval: 1000 });
-useDeviceMotion({ initial: { ... } });
 useDeviceMotion({ availability: false });
+useDeviceMotion({ initial: { ... } });
 ```
 
-With the `useDeviceMotion` hook we can create a simple component.
+
+## Example
 
 ```jsx
+import { useDeviceMotion } from '@use-expo/sensors';
+import { Text, View } from 'react-native';
+
 function DeviceMotionSensor() {
-    const [data, isAvailable] = useDeviceMotion({ interval: 100 });
+    const [data, available] = useDeviceMotion({ interval: 100 });
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>DeviceMotion:</Text>
-            {(isAvailable && data)
+            {(available && data)
                 ? <Text>{JSON.stringify(data, null, 2)}</Text>
                 : <Text>unavailable</Text>
             }
@@ -39,21 +59,20 @@ function DeviceMotionSensor() {
 }
 ```
 
+
 ## API
 
 ```ts
 import { DeviceMotionMeasurement } from 'expo-sensors';
 
-function useDeviceMotion(options?: DeviceMotionOptions): [
-    DeviceMotionMeasurement | undefined,
-    boolean | undefined,
-];
+function useDeviceMotion(options?: Options): Result;
 
-interface DeviceMotionOptions {
+interface Options {
     /** The initial data to use before the first update. */
     initial?: DeviceMotionMeasurement;
     /** If it should check the availability of the sensor, defaults to `true`. */
     availability?: boolean;
+
     /**
      * The interval, in ms, to update the device motion data.
      * Note, this is set globally through `DeviceMotion.setUpdateInterval`.
@@ -61,12 +80,15 @@ interface DeviceMotionOptions {
      */
     interval?: number;
 }
+
+type Result = [
+    DeviceMotionMeasurement | undefined,
+    boolean | undefined,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/docs/use-gyroscope.md
+++ b/packages/sensors/docs/use-gyroscope.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useGyroscope</code>
-        <br />
-        <br />
-    </h1>
-    tracks changes in rotation with <a href="https://docs.expo.io/versions/latest/sdk/gyroscope/"><code>Gyroscope</code></a>
+    <h1>useGyroscope</h1>
+    <p>Track changes in rotation with <a href="https://docs.expo.io/versions/latest/sdk/gyroscope/"><code>Gyroscope</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -17,20 +33,24 @@ const [data, isAvailable] = useGyroscope();
 
 // other options
 useGyroscope({ interval: 1000 });
-useGyroscope({ initial: { x: 1, y: 1, z: 1 } });
 useGyroscope({ availability: false });
+useGyroscope({ initial: { x: 1, y: 1, z: 1 } });
 ```
 
-With the `useGyroscope` hook we can simplify the [Gyroscope example for the Expo docs](https://docs.expo.io/versions/latest/sdk/gyroscope/#example-basic-subscription).
+
+## Example
 
 ```jsx
+import { useGyroscope } from '@use-expo/sensors';
+import { Text, View } from 'react-native';
+
 function GyroscopeSensor() {
-    const [data, isAvailable] = useGyroscope({ interval: 100 });
+    const [data, available] = useGyroscope({ interval: 100 });
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Gyroscope:</Text>
-            {(isAvailable && data)
+            {(available && data)
                 ? <Text>x: {round(data.x)} y: {round(data.y)} z: {round(data.z)}</Text>
                 : <Text>unavailable</Text>
             }
@@ -38,30 +58,25 @@ function GyroscopeSensor() {
     );
 }
 
-function round(n) {
-    if (!n) {
-        return 0;
-    }
-
-    return Math.floor(n * 100) / 100;
+function round(value = 0) {
+    return Math.floor(value * 100) / 100;
 }
 ```
+
 
 ## API
 
 ```ts
 import { ThreeAxisMeasurement } from 'expo-sensors';
 
-function useGyroscope(options?: GyroscopeOptions): [
-    ThreeAxisMeasurement | undefined,
-    boolean | undefined,
-];
+function useGyroscope(options?: Options): Result
 
-interface GyroscopeOptions {
+interface Options {
     /** The initial data to use before the first update. */
     initial?: ThreeAxisMeasurement;
     /** If it should check the availability of the sensor, defaults to `true`. */
     availability?: boolean;
+
     /**
      * The interval, in ms, to update the gyroscope data.
      * Note, this is set globally through `Gyroscope.setUpdateInterval`.
@@ -69,12 +84,15 @@ interface GyroscopeOptions {
      */
     interval?: number;
 }
+
+type Result = [
+    ThreeAxisMeasurement | undefined,
+    boolean | undefined,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/docs/use-magnetometer.md
+++ b/packages/sensors/docs/use-magnetometer.md
@@ -1,19 +1,36 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>useMagnetometer</code>
-        <br />
-        <br />
-    </h1>
-    tracks changes in the magnetic field with <a href="https://docs.expo.io/versions/latest/sdk/magnetometer/"><code>Magnetometer</code></a>
+    <h1>useMagnetometer</h1>
+    <p>Track changes in the magnetic field with <a href="https://docs.expo.io/versions/latest/sdk/magnetometer/"><code>Magnetometer</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
 const [data, isAvailable] = useMagnetometer();
+const [data, isAvailable] = useMagnetometerUncalibrated();
 
 // other options
 useMagnetometer({ interval: 1000 });
@@ -27,16 +44,20 @@ useMagnetometerUncalibrated({ initial: { x: 1, y: 1, z: 1 } });
 useMagnetometerUncalibrated({ availability: false });
 ```
 
-With the `useMagnetometer` hook we can simplify the [Magnetometer example for the Expo docs](https://docs.expo.io/versions/latest/sdk/magnetometer/#example-basic-subscription).
+
+## Example
 
 ```jsx
+import { useMagnetometer } from '@use-expo/sensors';
+import { Text, View } from 'react-native';
+
 function MagnetometerSensor() {
-    const [data, isAvailable] = useMagnetometer({ interval: 100 });
+    const [data, available] = useMagnetometer({ interval: 100 });
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Magnetometer:</Text>
-            {(isAvailable && data)
+            {(available && data)
                 ? <Text>x: {round(data.x)} y: {round(data.y)} z: {round(data.z)}</Text>
                 : <Text>unavailable</Text>
             }
@@ -44,30 +65,26 @@ function MagnetometerSensor() {
     );
 }
 
-function round(n) {
-    if (!n) {
-        return 0;
-    }
-
-    return Math.floor(n * 100) / 100;
+function round(value = 0) {
+    return Math.floor(value * 100) / 100;
 }
 ```
+
 
 ## API
 
 ```ts
 import { ThreeAxisMeasurement } from 'expo-sensors';
 
-function useMagnetometer(options?: MagnetometerOptions): [
-    ThreeAxisMeasurement | undefined,
-    boolean | undefined,
-];
+function useMagnetometer(options?: Options): Result;
+function useMagnetometerUncalibrated(options?: Options): Result;
 
-interface MagnetometerOptions {
+interface Options {
     /** The initial data to use before the first update. */
     initial?: ThreeAxisMeasurement;
     /** If it should check the availability of the sensor, defaults to `true`. */
     availability?: boolean;
+
     /**
      * The interval, in ms, to update the magnetometer data.
      * Note, this is set globally through `Magnetometer.setUpdateInterval`.
@@ -75,12 +92,15 @@ interface MagnetometerOptions {
      */
     interval?: number;
 }
+
+type Result = [
+    ThreeAxisMeasurement | undefined,
+    boolean | undefined,
+];
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/docs/use-pedometer-history.md
+++ b/packages/sensors/docs/use-pedometer-history.md
@@ -1,38 +1,58 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>usePedometerHistory</code>
-        <br />
-        <br />
-    </h1>
-    get historical step count with <a href="https://docs.expo.io/versions/latest/sdk/pedometer/"><code>Pedometer</code></a>
+    <h1>usePedometerHistory</h1>
+    <p>Get historical step count between two dates with <a href="https://docs.expo.io/versions/latest/sdk/pedometer/"><code>Pedometer</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
 const [data, isAvailable] = usePedometerHistory(start, end);
 
 // other options
-usePedometerHistory(start, end, { initial: { steps: 5 } });
-usePedometerHistory(start, end, { availability: false });
+usePedometerHistory({ start, end, availability: false });
+usePedometerHistory({ start, end, initial: { steps: 5 } });
 ```
 
-With the `usePedometerHistory` hook we can create a component based on the [Pedometer example for the Expo docs](https://docs.expo.io/versions/latest/sdk/pedometer/#usage).
+
+## Example
 
 ```jsx
+import { usePedometerHistory } from '@use-expo/sensors';
+import { Text, View } from 'react-native';
+
 function PedometerHistorySensor() {
-    const [data, isAvailable] = usePedometerHistory(
+    const [data, available] = usePedometerHistory(
         new Date('2019-07-03T12:00:00+02:00'),
         new Date('2019-07-03T16:00:00+02:00'),
     );
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Pedometer:</Text>
-            {(isAvailable && data)
+            {(available && data)
                 ? <Text>{data.steps} steps done in 4 hours</Text>
                 : <Text>unavailable</Text>
             }
@@ -41,10 +61,20 @@ function PedometerHistorySensor() {
 }
 ```
 
+
 ## API
 
 ```ts
-function usePedometerHistory(options?: PedometerOptions): [
+function usePedometerHistory(options?: Options): Result;
+
+interface Options {
+    /** The initial data to use before the first update. */
+    initial?: PedometerMeasurement;
+    /** If it should check the availability of the sensor, defaults to `true`. */
+    availability?: boolean;
+}
+
+type Result = [
     PedometerMeasurement | undefined,
     boolean | undefined,
 ];
@@ -53,19 +83,10 @@ interface PedometerMeasurement {
     /** The amount of steps made */
     steps: number;
 }
-
-interface PedometerOptions {
-    /** The initial data to use before the first update. */
-    initial?: PedometerMeasurement;
-    /** If it should check the availability of the sensor, defaults to `true`. */
-    availability?: boolean;
-}
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/sensors/docs/use-pedometer.md
+++ b/packages/sensors/docs/use-pedometer.md
@@ -1,15 +1,31 @@
 <div align="center">
-    <h1>
-        <br />
-        <code>usePedometer</code>
-        <br />
-        <br />
-    </h1>
-    tracks user step count with <a href="https://docs.expo.io/versions/latest/sdk/pedometer/"><code>Pedometer</code></a>
+    <h1>usePedometer</h1>
+    <p>Track user step count with <a href="https://docs.expo.io/versions/latest/sdk/pedometer/"><code>Pedometer</code></a></p>
+    <sup>
+        <a href="https://github.com/bycedric/use-expo/releases">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
+        </a>
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
+        </a>
+        <a href="https://exp.host/@bycedric/use-expo">
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
+        </a>
+    </sup>
+    <br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>Other hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
+    <br />
+    <pre>yarn add @use-expo/sensors expo-sensors</pre>
     <br />
 </div>
 
-## Examples
+## Usage
 
 ```jsx
 // full hook
@@ -20,16 +36,17 @@ usePedometer({ initial: { steps: 5 } });
 usePedometer({ availability: false });
 ```
 
-With the `usePedometer` hook we can create a component based on the [Pedometer example for the Expo docs](https://docs.expo.io/versions/latest/sdk/pedometer/#usage).
+
+## Example
 
 ```jsx
 function PedometerSensor() {
-    const [data, isAvailable] = usePedometer();
+    const [data, available] = usePedometer();
 
     return (
-        <View style={{ marginTop: 15, paddingHorizontal: 10 }}>
+        <View>
             <Text>Pedometer:</Text>
-            {(isAvailable && data)
+            {(available && data)
                 ? <Text>{data.steps} steps</Text>
                 : <Text>unavailable</Text>
             }
@@ -38,10 +55,20 @@ function PedometerSensor() {
 }
 ```
 
+
 ## API
 
 ```ts
-function usePedometer(options?: PedometerOptions): [
+function usePedometer(options?: Options): Result;
+
+interface Options {
+    /** The initial data to use before the first update. */
+    initial?: PedometerMeasurement;
+    /** If it should check the availability of the sensor, defaults to `true`. */
+    availability?: boolean;
+}
+
+type Result = [
     PedometerMeasurement | undefined,
     boolean | undefined,
 ];
@@ -50,19 +77,10 @@ interface PedometerMeasurement {
     /** The amount of steps made */
     steps: number;
 }
-
-interface PedometerOptions {
-    /** The initial data to use before the first update. */
-    initial?: PedometerMeasurement;
-    /** If it should check the availability of the sensor, defaults to `true`. */
-    availability?: boolean;
-}
 ```
 
 <div align="center">
     <br />
-    <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/use-expo/README.md
+++ b/packages/use-expo/README.md
@@ -1,27 +1,21 @@
 <div align="center">
-    <h1>
-        <br />
-        expo hooks
-        <br />
-        <br />
-    </h1>
+    <h1>use-expo</h1>
+    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg" alt="releases" />
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
-        <a href="https://travis-ci.com/byCedric/use-expo">
-            <img src="https://img.shields.io/travis/com/byCedric/use-expo/master.svg" alt="builds" />
+        <a href="https://github.com/bycedric/use-expo/actions">
+            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
-        <br />
-        Complementary hooks for Expo
     </sup>
     <br />
+	<br />
     <br />
-    <pre>npm i <a href="https://www.npmjs.com/package/use-expo">use-expo</a></pre>
-    <br />
+    <pre>npm i -S use-expo</pre>
 </div>
 
 > See [`README.md`](https://github.com/bycedric/use-expo) in root.
@@ -30,6 +24,5 @@
     <br />
     <br />
     with :heart: <strong>byCedric</strong>
-    <br />
     <br />
 </div>

--- a/packages/use-expo/README.md
+++ b/packages/use-expo/README.md
@@ -1,27 +1,31 @@
 <div align="center">
-    <h1>use-expo</h1>
-    <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
+    <h1>expo hooks</h1>
+     <p>Complementary hooks for <a href="https://github.com/expo/expo">Expo</a></p>
     <sup>
         <a href="https://github.com/bycedric/use-expo/releases">
             <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="releases" />
         </a>
         <a href="https://github.com/bycedric/use-expo/actions">
-            <img src="https://img.shields.io/github/release/byCedric/use-expo/all.svg?style=flat-square" alt="builds" />
+            <img src="https://img.shields.io/github/workflow/status/byCedric/use-expo/Packages/master.svg?style=flat-square" alt="builds" />
         </a>
         <a href="https://exp.host/@bycedric/use-expo">
-            <img src="https://img.shields.io/badge/demo-expo-lightgrey.svg?style=flat-square" alt="demo" />
+            <img src="https://img.shields.io/badge/demo-expo.io-lightgrey.svg?style=flat-square" alt="demo" />
         </a>
     </sup>
     <br />
-	<br />
+    <p align="center">
+        <a href="https://github.com/byCedric/use-expo#readme"><b>All hooks</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo#usage"><b>Usage</b></a>
+        &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+        <a href="https://github.com/byCedric/use-expo/blob/master/CHANGELOG.md"><b>Changelog</b></a>
+    </p>
     <br />
-    <pre>npm i -S use-expo</pre>
+    <pre>yarn add use-expo</pre>
+    <br />
 </div>
 
-> See [`README.md`](https://github.com/bycedric/use-expo) in root.
-
 <div align="center">
-    <br />
     <br />
     with :heart: <strong>byCedric</strong>
     <br />


### PR DESCRIPTION
### Linked issue
This should help:
  - navigating back and forth
  - copying working examples without additional code
  - understanding the API sections
  - links to GH actions
  - info about `use-expo` vs `@use-expo/*`
