### PR TITLE
fix(font): avoid render loop when using inline fontmaps

### DIFF
--- a/packages/font/src/use-fonts.ts
+++ b/packages/font/src/use-fonts.ts
@@ -6,6 +6,8 @@ import { FontSource, loadAsync } from 'expo-font';
  * The map keys are used as font names, and can be used with `fontFamily: <name>;`.
  * It returns a boolean describing if all fonts are loaded.
  *
+ * Note, the fonts are not "reloaded" when you dynamically change the font map.
+ *
  * @see https://docs.expo.io/versions/latest/sdk/font/
  * @example const [isLoaded] = useFonts(...);
  */
@@ -13,9 +15,12 @@ export function useFonts(map: FontMap): [boolean] {
 	const [loaded, setLoaded] = useState(false);
 
 	useEffect(() => {
-		loadAsync(map).then(() => setLoaded(true));
-		return () => setLoaded(false);
-	}, [map]);
+		loadAsync(map).then(() => setLoaded(true))
+	}, []); // eslint-disable-line
+
+	// note: to avoid any ambigouty fonts are only loaded once
+	// since every rerender is a new object, we have no way of
+	// detecting a new map and updating the loaded state based on that
 
 	return [loaded];
 }

--- a/packages/font/tests/use-fonts.test.ts
+++ b/packages/font/tests/use-fonts.test.ts
@@ -20,22 +20,32 @@ it('loads fonts when mounted', async () => {
 	expect(hook.result.current[DATA]).toBe(true);
 });
 
-it('loads new fonts map when rerendered', async () => {
+it('skips new font map when rerendered', async () => {
 	const loader = jest.spyOn(Font, 'loadAsync').mockResolvedValue();
+
+	const hook = renderHook(useFonts, { initialProps: FONTS });
+	await hook.waitForNextUpdate();
+
+	expect(loader).toBeCalledWith(FONTS);
+
 	const partialFonts = { ...FONTS };
 	delete partialFonts['ComicSans-Regular'];
 
-	const hook = renderHook(useFonts, { initialProps: partialFonts });
-	await hook.waitForNextUpdate();
+	hook.rerender(partialFonts);
 
-	expect(loader).toBeCalledWith(partialFonts);
+	expect(hook.result.current[DATA]).toBe(true);
+	expect(loader).not.toBeCalledWith(partialFonts);
+});
 
-	hook.rerender(FONTS);
+it('keeps fonts loaded when unmounted', async () => {
+	jest.spyOn(Font, 'loadAsync').mockResolvedValue();
 
-	expect(hook.result.current[DATA]).toBe(false);
-
+	const hook = renderHook(useFonts, { initialProps: FONTS });
 	await hook.waitForNextUpdate();
 
 	expect(hook.result.current[DATA]).toBe(true);
-	expect(loader).toBeCalledWith(FONTS);
+
+	hook.unmount();
+
+	expect(hook.result.current[DATA]).toBe(true);
 });


### PR DESCRIPTION
### Linked issue
Fixes #127 
