### PR TITLE
refactor(example): update fonts example with inline fontmap

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -36,9 +36,10 @@
 		"react": "~16.9.0",
 		"react-dom": "~16.9.0",
 		"react-native": "https://github.com/expo/react-native/archive/sdk-36.0.1.tar.gz",
-		"react-native-gesture-handler": "~1.6.0",
+		"react-native-gesture-handler": "~1.5.0",
 		"react-native-paper": "^2.16.0",
 		"react-native-reanimated": "~1.4.0",
+		"react-native-screens": "2.0.0-alpha.12",
 		"react-native-web": "^0.12.1",
 		"react-navigation": "^4.0.10",
 		"react-navigation-stack": "^1.10.3"

--- a/example/src/molecules/font/use-fonts.tsx
+++ b/example/src/molecules/font/use-fonts.tsx
@@ -5,12 +5,10 @@ import { Example, Information, Link, Page } from '../../atoms';
 import { MoleculeProps } from '../../providers/molecule';
 import { docs } from '../../providers/urls';
 
-const customFonts = {
-	ComicSans: require('../../assets/fonts/comic-sans-ms/regular.ttf'),
-};
-
 export const UseFonts: React.SFC<MoleculeProps> = (props) => {
-	const [loaded] = useFonts(customFonts);
+	const [loaded] = useFonts({
+		ComicSans: require('../../assets/fonts/comic-sans-ms/regular.ttf'),
+	});
 
 	return (
 		<Page

--- a/yarn.lock
+++ b/yarn.lock
@@ -8165,6 +8165,12 @@ gzip-size@5.1.1, gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
+"hammerjs@git+https://github.com/naver/hammer.js.git":
+  version "2.0.17-snapshot"
+  resolved "git+https://github.com/naver/hammer.js.git#54bc698b25edd6e1b76ca975ebaced5ce0467d51"
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 handlebars@^4.4.0:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.1.tgz#052bd2618964dcb8aebad0940bfeb2d8d1cfbfde"
@@ -13133,12 +13139,13 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-native-gesture-handler@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.6.0.tgz#e9a4e1d0c7ac21eb0d6b6ec013e73f9c0c33a629"
-  integrity sha512-KulGCWKTxa6xBpPP4LWEPmmLqBqOe2jbtdlILOVF/dR4EgImiaBVrKdOHeRMyMzJOYAWxs5uDZsyA8hgSsm+lw==
+react-native-gesture-handler@~1.5.0:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.6.tgz#5d90145f624e3707db2930f43ab41579683e2375"
+  integrity sha512-z2jLUkRiRc0PBAC9UcXYkqy3VUzBG0cYQAGMsDHsd90JgrzudHAFRJV9fvFm18wNauFTNnJievjZ0C3rI2ydhw==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
+    hammerjs "https://github.com/naver/hammer.js.git"
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.4"
     prop-types "^15.7.2"
@@ -13173,6 +13180,13 @@ react-native-safe-area-view@^0.14.8:
   integrity sha512-MtRSIcZNstxv87Jet+UsPhEd1tpGe8cVskDXlP657x6rHpSrbrc+y13ZNXrwAgGNNhqQNX7UJT68ZIq//ZRmvw==
   dependencies:
     hoist-non-react-statics "^2.3.1"
+
+react-native-screens@2.0.0-alpha.12:
+  version "2.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.12.tgz#35a6ef3b472958e9d35f0ca9e582d0d158f8e379"
+  integrity sha512-x9M7FEdcm97bVDp3pi//nhduJHLFMrmDQs0fq299yx3kHdgHbrmhsa8jgW4HvDQhjyPE0FWADY/GrXFuPRj80w==
+  dependencies:
+    debounce "^1.2.0"
 
 react-native-view-shot@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### Linked issue
Updates some wrong dependency updates in the example, and a minor update for the fonts example.