### PR TITLE
chore: remove preview filtering from the workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,6 @@
 ---
 name: Preview
-on:
-  pull_request:
-    branches-ignore: [master]
+on: [pull_request]
 jobs:
   preview:
     name: Publish preview


### PR DESCRIPTION
### Linked issue
It won't work for branches pushed to an ignored repository. 😅 
