### PR TITLE
chore: upgrade to latest github action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 12.x
 
       - name: Setup Expo
-        uses: expo/expo-github-action@v5
+        uses: expo/expo-github-action@master
         with:
           expo-version: 3.x
           expo-username: bycedric


### PR DESCRIPTION
### Linked issue
Tests the latest github action on master, should be future `5.2.0`.
